### PR TITLE
Next broker hint

### DIFF
--- a/bin/cetus-drone-client
+++ b/bin/cetus-drone-client
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+BINDIR=$(dirname "$0")
+PULSAR_HOME=`cd $BINDIR/..;pwd`
+
+DEFAULT_CLIENT_CONF=$PULSAR_HOME/conf/client.conf
+DEFAULT_LOG_CONF=$PULSAR_HOME/conf/log4j2.yaml
+
+if [ -f "$PULSAR_HOME/conf/pulsar_tools_env.sh" ]
+then
+    . "$PULSAR_HOME/conf/pulsar_tools_env.sh"
+fi
+
+# Check for the java to use
+if [[ -z $JAVA_HOME ]]; then
+    JAVA=$(which java)
+    if [ $? != 0 ]; then
+        echo "Error: JAVA_HOME not set, and no java executable found in $PATH." 1>&2
+        exit 1
+    fi
+else
+    JAVA=$JAVA_HOME/bin/java
+fi
+
+# exclude tests jar
+RELEASE_JAR=`ls $PULSAR_HOME/pulsar-*.jar 2> /dev/null | grep -v tests | tail -1` 
+if [ $? == 0 ]; then
+    PULSAR_JAR=$RELEASE_JAR
+fi
+
+# exclude tests jar
+BUILT_JAR=`ls $PULSAR_HOME/pulsar-client-tools/target/pulsar-*.jar 2> /dev/null | grep -v tests | tail -1`
+if [ $? != 0 ] && [ ! -e "$PULSAR_JAR" ]; then 
+    echo "\nCouldn't find pulsar jar.";
+    echo "Make sure you've run 'mvn package'\n";
+    exit 1;
+elif [ -e "$BUILT_JAR" ]; then
+    PULSAR_JAR=$BUILT_JAR
+fi
+
+add_maven_deps_to_classpath() {
+    MVN="mvn"
+    if [ "$MAVEN_HOME" != "" ]; then
+	MVN=${MAVEN_HOME}/bin/mvn
+    fi
+    
+    # Need to generate classpath from maven pom. This is costly so generate it
+    # and cache it. Save the file into our target dir so a mvn clean will get
+    # clean it up and force us create a new one.
+    f="${PULSAR_HOME}/distribution/server/target/classpath.txt"
+    if [ ! -f "${f}" ]
+    then
+	${MVN} -f "${PULSAR_HOME}/pom.xml" dependency:build-classpath -Dmdep.outputFile="${f}" &> /dev/null
+    fi
+    PULSAR_CLASSPATH=${CLASSPATH}:`cat "${f}"`
+}
+
+if [ -d "$PULSAR_HOME/lib" ]; then
+	PULSAR_CLASSPATH="$PULSAR_CLASSPATH:$PULSAR_HOME/lib/*"
+else
+    add_maven_deps_to_classpath
+fi
+
+if [ -z "$PULSAR_CLIENT_CONF" ]; then
+    PULSAR_CLIENT_CONF=$DEFAULT_CLIENT_CONF
+fi
+if [ -z "$PULSAR_LOG_CONF" ]; then
+    PULSAR_LOG_CONF=$DEFAULT_LOG_CONF
+fi
+
+PULSAR_CLASSPATH="$PULSAR_JAR:$PULSAR_CLASSPATH:$PULSAR_EXTRA_CLASSPATH"
+PULSAR_CLASSPATH="`dirname $PULSAR_LOG_CONF`:$PULSAR_CLASSPATH"
+OPTS="$OPTS -Dlog4j.configurationFile=`basename $PULSAR_LOG_CONF`"
+OPTS="$OPTS -Djava.net.preferIPv4Stack=true"
+
+OPTS="-cp $PULSAR_CLASSPATH $OPTS"
+
+OPTS="$OPTS $PULSAR_EXTRA_OPTS"
+
+# log directory & file
+PULSAR_LOG_DIR=${PULSAR_LOG_DIR:-"$PULSAR_HOME/logs"}
+PULSAR_LOG_APPENDER=${PULSAR_LOG_APPENDER:-"Console"}
+
+#Configure log configuration system properties
+OPTS="$OPTS -Dpulsar.log.dir=$PULSAR_LOG_DIR"
+OPTS="$OPTS -Dpulsar.log.appender=$PULSAR_LOG_APPENDER"
+
+#Change to PULSAR_HOME to support relative paths
+cd "$PULSAR_HOME"
+
+exec $JAVA $OPTS org.apache.pulsar.client.cli.CetusDroneClient $PULSAR_CLIENT_CONF "$@"

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -68,6 +68,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Enable the WebSocket API service
     private boolean webSocketServiceEnabled = false;
 
+    private boolean proactiveLoadingEnabled = true;
+
     // Flag to control features that are meant to be used when running in standalone mode
     private boolean isRunningStandalone = false;
 
@@ -613,6 +615,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setNumIOThreads(int numIOThreads) {
         this.numIOThreads = numIOThreads;
+    }
+
+    public boolean isProactiveLoadingEnabled() {
+        return proactiveLoadingEnabled;
+    }
+
+    public void setProactiveLoadingEnabled(boolean proactiveLoadingEnabled) {
+        this.proactiveLoadingEnabled = proactiveLoadingEnabled;
     }
 
     public boolean isWebSocketServiceEnabled() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -70,6 +70,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     private boolean proactiveLoadingEnabled = true;
 
+    private int numUnloadThreads = 16;
+
     // Flag to control features that are meant to be used when running in standalone mode
     private boolean isRunningStandalone = false;
 
@@ -615,6 +617,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setNumIOThreads(int numIOThreads) {
         this.numIOThreads = numIOThreads;
+    }
+
+    public int getNumUnloadThreads() {
+        return numUnloadThreads;
+    }
+
+    public void setNumUnloadThreads(int num) {
+        this.numUnloadThreads = num;
     }
 
     public boolean isProactiveLoadingEnabled() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -151,8 +151,7 @@ public class PulsarService implements AutoCloseable {
     public static final String COORDINATE_DATA_PATH = "/cetus/coordinate-data";
 
 
-    private final ScheduledExecutorService unloadExecutor = Executors.newScheduledThreadPool(16,
-            new DefaultThreadFactory("unload-exec"));
+    private final ScheduledExecutorService unloadExecutor;
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(20,
             new DefaultThreadFactory("pulsar"));
     private final ScheduledExecutorService cacheExecutor = Executors.newScheduledThreadPool(10,
@@ -230,6 +229,7 @@ public class PulsarService implements AutoCloseable {
 		this.shutdownService = new MessagingServiceShutdownHook(this);
 		this.loadManagerExecutor = Executors
 			.newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-load-manager"));
+        this.unloadExecutor = Executors.newScheduledThreadPool(config.getNumUnloadThreads(), new DefaultThreadFactory("unload-exec"));
 		this.functionWorkerService = functionWorkerService;
 		// Cetus Netowrk Coordinate Data
 		//this.cetusNetworkCoordinateData = new CetusNetworkCoordinateData();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -526,6 +526,21 @@ public abstract class NamespacesBase extends AdminResource {
     }
 
     @SuppressWarnings("deprecation")
+    public void internalProactivelyOwnNamespaceBundle(String bundleRange, String nextBroker, boolean authoritative) {
+        if (authoritative) { // TODO Also check if the nextBroker is equal to myself (broker)
+            log.info("About to actually proactivelyOwnBundle {}", bundleRange);
+            Policies policies = getNamespacePolicies(namespaceName);
+            //if (isBundleOwnedByAnyBroker(namespaceName, policies.bundles, bundleRange)) {
+            //    log.info("[{}] Namespace bundle is not owned by any broker {}/{}", clientAppId(), namespaceName,
+            //            bundleRange);
+            NamespaceBundle bundle = validateNamespaceBundleRange(namespaceName, policies.bundles, bundleRange);
+            pulsar().getNamespaceService().proactivelyOwnBundleAndRetry(bundle);
+        } else {
+            redirectProactivelyOwnCall(bundleRange, nextBroker);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
     public void internalUnloadNamespaceBundle(String bundleRange, boolean authoritative) {
         this.internalUnloadNamespaceBundle(bundleRange, authoritative, null);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -527,7 +527,12 @@ public abstract class NamespacesBase extends AdminResource {
 
     @SuppressWarnings("deprecation")
     public void internalUnloadNamespaceBundle(String bundleRange, boolean authoritative) {
-        log.info("[{}] Unloading namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange);
+        this.internalUnloadNamespaceBundle(bundleRange, authoritative, null);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void internalUnloadNamespaceBundle(String bundleRange, boolean authoritative, String nextBroker) {
+        log.info("[{}] Unloading namespace bundle {}/{} w/ nextBroker {}", clientAppId(), namespaceName, bundleRange, nextBroker);
 
         validateSuperUserAccess();
         Policies policies = getNamespacePolicies(namespaceName);
@@ -551,7 +556,7 @@ public abstract class NamespacesBase extends AdminResource {
         NamespaceBundle nsBundle = validateNamespaceBundleOwnership(namespaceName, policies.bundles, bundleRange,
                 authoritative, true);
         try {
-            pulsar().getNamespaceService().unloadNamespaceBundle(nsBundle);
+            pulsar().getNamespaceService().unloadNamespaceBundle(nsBundle, nextBroker);
             log.info("[{}] Successfully unloaded namespace bundle {}", clientAppId(), nsBundle.toString());
         } catch (Exception e) {
             log.error("[{}] Failed to unload namespace bundle {}/{}", clientAppId(), namespaceName, bundleRange, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -380,6 +380,19 @@ public class Namespaces extends NamespacesBase {
     }
 
     @PUT
+    @Path("/{property}/{cluster}/{namespace}/{bundle}/proactivelyown")
+    @ApiOperation(hidden = true, value = "Unload a namespace bundle")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public void proactivelyOwnNamespaceBundle(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("bundle") String bundleRange,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("nextBroker") String nextBroker) {
+        log.info("proactivelyOwn in v1 Namespaces for bundle {}", bundleRange);
+        validateNamespaceName(property, cluster, namespace);
+        internalProactivelyOwnNamespaceBundle(bundleRange, nextBroker, authoritative);
+    }
+
+    @PUT
     @Path("/{property}/{cluster}/{namespace}/{bundle}/unload")
     @ApiOperation(hidden = true, value = "Unload a namespace bundle")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -385,9 +385,11 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
     public void unloadNamespaceBundle(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("bundle") String bundleRange,
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("nextBroker") String nextBroker) {
+        log.info("nextBroker in v1 Namespaces = {}", nextBroker);
         validateNamespaceName(property, cluster, namespace);
-        internalUnloadNamespaceBundle(bundleRange, authoritative);
+        internalUnloadNamespaceBundle(bundleRange, authoritative, nextBroker);
     }
 
     @PUT

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -393,6 +393,16 @@ public class Namespaces extends NamespacesBase {
     }
 
     @PUT
+    @Path("/{property}/{cluster}/{namespace}/{bundle}/unload_legacy")
+    @ApiOperation(hidden = true, value = "Unload a namespace bundle")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public void unloadNamespaceBundle(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("bundle") String bundleRange,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        unloadNamespaceBundle(property, cluster, namespace, bundleRange, authoritative, null);
+    }
+
+    @PUT
     @Path("/{property}/{cluster}/{namespace}/{bundle}/unload")
     @ApiOperation(hidden = true, value = "Unload a namespace bundle")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -284,9 +284,11 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
     public void unloadNamespaceBundle(@PathParam("tenant") String tenant, @PathParam("namespace") String namespace,
             @PathParam("bundle") String bundleRange,
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("nextBroker") String nextBroker) {
+        log.info("nextBroker in v2 Namespaces = {}", nextBroker);
         validateNamespaceName(tenant, namespace);
-        internalUnloadNamespaceBundle(bundleRange, authoritative);
+        internalUnloadNamespaceBundle(bundleRange, authoritative, nextBroker);
     }
 
     @PUT

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/CetusBundleUnloadingStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/CetusBundleUnloadingStrategy.java
@@ -40,5 +40,5 @@ public interface CetusBundleUnloadingStrategy {
      *            The service configuration.
      * @return A map from all selected bundles to Pair(currBroker, nextCandidateBroker)
      */
-    Multimap<String, BrokerChange> findBundlesForUnloading(ConcurrentHashMap<String, CetusBrokerData> cetusBrokerDataMap, ServiceConfiguration conf, NamespaceService namespaceService);
+    Multimap<String, BrokerChange> findBundlesForUnloading(ConcurrentHashMap<String, CetusBrokerData> cetusBrokerDataMap, ServiceConfiguration conf, String loadMgrAddress);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/CetusPeriodicLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/CetusPeriodicLoadManager.java
@@ -1,0 +1,7 @@
+package org.apache.pulsar.broker.loadbalance;
+
+public interface CetusPeriodicLoadManager extends ModularLoadManager {
+    public static int CETUS_LATENCY_BOUND_MS = 75;
+    public static int PERIOD_SEC = 30;
+    public static int WARMUP_SECS = 60;
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/CetusPeriodicLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/CetusPeriodicLoadManager.java
@@ -1,7 +1,8 @@
 package org.apache.pulsar.broker.loadbalance;
 
 public interface CetusPeriodicLoadManager extends ModularLoadManager {
-    public static int CETUS_LATENCY_BOUND_MS = 75;
-    public static int PERIOD_SEC = 30;
+    public static int CETUS_LATENCY_BOUND_MS = 75000;
     public static int WARMUP_SECS = 60;
+    public static String BROKER_LIST_LOC = "/tmp/brokerslist.txt";
+    public static String TARGET_BROKER = "/tmp/targetbroker.txt";
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
+import org.apache.pulsar.broker.loadbalance.impl.PeriodicLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.stats.Metrics;
@@ -141,7 +142,11 @@ public interface LoadManager {
                 final LoadManager casted = new ModularLoadManagerWrapper((CetusModularLoadManager) loadManagerInstance);
                 casted.initialize(pulsar);
                 return casted;
-            }
+            } else if (loadManagerInstance instanceof CetusPeriodicLoadManager) {
+                final LoadManager casted = new PeriodicLoadManagerWrapper((CetusPeriodicLoadManager) loadManagerInstance);
+                casted.initialize(pulsar);
+                return casted;
+            }  
         } catch (Exception e) {
             log.warn("Error when trying to create load manager: {}");
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusAllLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusAllLoadShedder.java
@@ -64,7 +64,9 @@ public class CetusAllLoadShedder  implements CetusBundleUnloadingStrategy {
         log.info("ALL_LOAD_SHEDDER SelectedBundleCache: {}", selectedBundleCache.toString());
         log.info("ALL_LOAD_SHEDDER Finding Bundles to Unload: Brokers: {} ", cetusBrokerDataMap.entrySet());
         for(Map.Entry<String, CetusBrokerData> entry : cetusBrokerDataMap.entrySet()) {
+            log.info("ALL_LOAD_SHEDDER Checking CetusBrokerData for broker {}", entry.getKey());
             for(Map.Entry<String, CetusNetworkCoordinateData> topicEntry : entry.getValue().getBundleNetworkCoordinates().entrySet()) {
+                log.info("ALL_LOAD_SHEDDER Adding bundle {} on broker {} for load shedding", topicEntry.getKey(), entry.getKey());
                 selectedBundleCache.put(entry.getKey(), new BrokerChange(topicEntry.getKey(), null));
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusAllLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusAllLoadShedder.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.apache.commons.lang3.mutable.MutableDouble;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.broker.BundleData;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.TimeAverageMessageData;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
+import org.apache.pulsar.broker.loadbalance.CetusBundleUnloadingStrategy;
+import org.apache.pulsar.common.util.CoordinateUtil;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.CetusBrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.CetusNetworkCoordinateData;
+import org.apache.pulsar.broker.loadbalance.CetusModularLoadManager;
+import org.apache.pulsar.broker.loadbalance.BrokerChange;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Load shedding strategy which will attempt to unload bundles from brokers who are actually
+ * closer to other brokers, until we have a better bundle shedding strategy
+ * 
+ * 
+ * 
+ * 
+ */
+public class CetusAllLoadShedder  implements CetusBundleUnloadingStrategy {
+
+    private static final Logger log = LoggerFactory.getLogger(CetusLoadShedder.class);
+
+    private final Multimap<String, BrokerChange> selectedBundleCache = ArrayListMultimap.create();
+
+    public Multimap<String, BrokerChange> findBundlesForUnloading(ConcurrentHashMap<String, CetusBrokerData> cetusBrokerDataMap, ServiceConfiguration conf, String loadMgrAddress) {
+        selectedBundleCache.clear();
+        log.info("ALL_LOAD_SHEDDER LOAD MANAGER ADDR : {}", loadMgrAddress.split("//")[1]);
+        log.info("ALL_LOAD_SHEDDER SelectedBundleCache: {}", selectedBundleCache.toString());
+        log.info("ALL_LOAD_SHEDDER Finding Bundles to Unload: Brokers: {} ", cetusBrokerDataMap.entrySet());
+        for(Map.Entry<String, CetusBrokerData> entry : cetusBrokerDataMap.entrySet()) {
+            for(Map.Entry<String, CetusNetworkCoordinateData> topicEntry : entry.getValue().getBundleNetworkCoordinates().entrySet()) {
+                selectedBundleCache.put(entry.getKey(), new BrokerChange(topicEntry.getKey(), null));
+            }
+        }
+        log.info("Load Shedding Completed");
+        return selectedBundleCache;
+    } 
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusLoadShedder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusLoadShedder.java
@@ -58,8 +58,9 @@ public class CetusLoadShedder  implements CetusBundleUnloadingStrategy {
 
     private final Multimap<String, BrokerChange> selectedBundleCache = ArrayListMultimap.create();
 
-    public Multimap<String, BrokerChange> findBundlesForUnloading(ConcurrentHashMap<String, CetusBrokerData> cetusBrokerDataMap, ServiceConfiguration conf, NamespaceService namespaceService) {
+    public Multimap<String, BrokerChange> findBundlesForUnloading(ConcurrentHashMap<String, CetusBrokerData> cetusBrokerDataMap, ServiceConfiguration conf, String loadMgrAddress) {
         selectedBundleCache.clear();
+        log.info("LOAD MANAGER ADDR : {}", loadMgrAddress.split("//")[1]);
         log.info("SelectedBundleCache: {}", selectedBundleCache.toString());
         log.info("Finding Bundles to Unload: Brokers: {} ", cetusBrokerDataMap.entrySet());
         for(Map.Entry<String, CetusBrokerData> entry : cetusBrokerDataMap.entrySet()) {
@@ -73,6 +74,10 @@ public class CetusLoadShedder  implements CetusBundleUnloadingStrategy {
                     for(Map.Entry<String, CetusBrokerData> brokerEntry : cetusBrokerDataMap.entrySet()) {
                         if (brokerEntry.getKey().equals(entry.getKey())) 
                             continue;
+                        
+                        if (brokerEntry.getKey().equals(loadMgrAddress.split("//")[1]))
+                            continue;
+
                         double distToOtherBroker = CoordinateUtil.calculateDistance(topicEntry.getValue().getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate());
                         log.info("[Cetus Load Shedder] Distance of bundle {} to broker {} = {}", topicEntry.getKey(), brokerEntry.getKey(), distToOtherBroker);
                         if (distToOtherBroker*1000.0 < CetusModularLoadManager.CETUS_LATENCY_BOUND_MS) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusModularLoadManagerImpl.java
@@ -843,7 +843,7 @@ public class CetusModularLoadManagerImpl implements CetusModularLoadManager, Zoo
                             log.info("desiredBrokerForBundle = {}", this.desiredBrokerForBundle);
 
                             //performUnloading(broker, bundle, bundleRange, namespaceName);
-                            pulsar.getUnloadExecutor().execute(() -> performUnloading(broker, bundle, bundleRange, namespaceName));
+                            pulsar.getUnloadExecutor().execute(() -> performUnloading(broker, bundle, bundleRange, namespaceName, nextBroker));
                             //pulsar.getExecutor().execute(() -> performUnloading(broker, bundle, bundleRange, namespaceName));
                             cetusLoadData.getLoadData().getRecentlyUnloadedBundles().put(bundle, System.currentTimeMillis());
                             }
@@ -851,10 +851,11 @@ public class CetusModularLoadManagerImpl implements CetusModularLoadManager, Zoo
                     });
         }
 
-    private void performUnloading(String broker, String bundle, String bundleRange, String namespaceName) {
-        log.info("[Cetus Bundle Unload Strategy] Unloading bundle: {} from broker {} at ts = {}", bundle, broker, System.currentTimeMillis());
+    private void performUnloading(String broker, String bundle, String bundleRange, String namespaceName, String nextBroker) {
+        log.info("[Cetus Bundle Unload Strategy] Unloading bundle: {} from broker {} to broker {} at ts = {}", bundle, broker, nextBroker, System.currentTimeMillis());
+        String[] brokerSplit = nextBroker.split(":");
         try {
-            pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespaceName, bundleRange);
+            pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespaceName, bundleRange, brokerSplit[0]);
         } catch (PulsarServerException | PulsarAdminException e) {
             log.warn("Error when trying to perform load shedding on {} for broker {}", bundle, broker, e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusModularLoadManagerImpl.java
@@ -817,7 +817,7 @@ public class CetusModularLoadManagerImpl implements CetusModularLoadManager, Zoo
 
             recentlyUnloadedBundles.keySet().removeIf(e -> recentlyUnloadedBundles.get(e) < timeout);
 
-            final Multimap<String, BrokerChange> bundlesToUnload = bundleUnloadingStrategy.findBundlesForUnloading(cetusLoadData.getCetusBrokerDataMap(), conf, pulsar.getNamespaceService());
+            final Multimap<String, BrokerChange> bundlesToUnload = bundleUnloadingStrategy.findBundlesForUnloading(cetusLoadData.getCetusBrokerDataMap(), conf, pulsar.getWebServiceAddress());
             log.info("Bundles to Unload: {}", bundlesToUnload.asMap());
 
             bundlesToUnload.asMap().forEach((broker, brokerChanges) -> {
@@ -1050,6 +1050,7 @@ private void getBrokersMeetLatency(final String bundle, int latencyReqMs) {
 
     log.info("Getting broker with least latency. Brokers to select from: {}", cetusLoadData.getCetusBrokerDataMap().size());
     for(Map.Entry<String, CetusBrokerData> brokerEntry : cetusLoadData.getCetusBrokerDataMap().entrySet()) {
+        
         if(cetusLoadData.getCetusBundleDataMap().containsKey(bundle)) {
             log.info("Attempting to find closer broker: {} Distance: {}", brokerEntry.getKey(), CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()));
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusPeriodicLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/CetusPeriodicLoadManagerImpl.java
@@ -1,0 +1,1301 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import static org.apache.pulsar.broker.admin.AdminResource.jsonMapper;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
+import static org.apache.pulsar.broker.web.PulsarWebResource.path;
+import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.gson.Gson;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.FileHandler;
+import java.util.logging.SimpleFormatter;
+import java.io.FileWriter;
+
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.pulsar.broker.BrokerData;
+import org.apache.pulsar.broker.BundleData;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.TimeAverageBrokerData;
+import org.apache.pulsar.broker.TimeAverageMessageData;
+import org.apache.pulsar.broker.loadbalance.BrokerFilter;
+import org.apache.pulsar.broker.loadbalance.BrokerFilterException;
+import org.apache.pulsar.broker.loadbalance.BrokerHostUsage;
+import org.apache.pulsar.broker.loadbalance.BundleSplitStrategy;
+import org.apache.pulsar.broker.loadbalance.CetusPeriodicLoadManager;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.broker.loadbalance.LoadManager;
+import org.apache.pulsar.broker.loadbalance.LoadSheddingStrategy;
+import org.apache.pulsar.broker.loadbalance.ModularLoadManager;
+import org.apache.pulsar.broker.loadbalance.ModularLoadManagerStrategy;
+import org.apache.pulsar.broker.loadbalance.CetusBundleUnloadingStrategy;
+import org.apache.pulsar.broker.loadbalance.BrokerChange;
+import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.naming.NamespaceBundleFactory;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.ServiceUnitId;
+import org.apache.pulsar.common.policies.data.FailureDomain;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.ResourceQuota;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.broker.stats.prometheus.TopicMigrationStats;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
+import org.apache.pulsar.policies.data.loadbalancer.CetusBrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.CetusNetworkCoordinateData;
+import org.apache.pulsar.policies.data.loadbalancer.SystemResourceUsage;
+import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
+import org.apache.pulsar.zookeeper.ZooKeeperCacheListener;
+import org.apache.pulsar.zookeeper.ZooKeeperChildrenCache;
+import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.apache.pulsar.broker.loadbalance.CetusLoadData;
+import org.apache.pulsar.common.policies.data.NetworkCoordinate;
+import org.apache.pulsar.common.util.CoordinateUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CetusPeriodicLoadManagerImpl implements CetusPeriodicLoadManager, ZooKeeperCacheListener<CetusBrokerData> {
+    private static final Logger log = LoggerFactory.getLogger(CetusPeriodicLoadManagerImpl.class);
+
+    private static final java.util.logging.Logger bundleStatsLog = java.util.logging.Logger.getLogger(CetusPeriodicLoadManagerImpl.class.getName());
+
+    // Path to ZNode whose children contain BundleData jsons for each bundle (new API version of ResourceQuota).
+    public static final String BUNDLE_DATA_ZPATH = "/loadbalance/bundle-data";
+
+    public static final String CETUS_COORDINATE_DATA_ROOT = "/cetus/coordinate-data";
+
+    // Default message rate to assume for unseen bundles.
+    public static final double DEFAULT_MESSAGE_RATE = 50;
+
+    // Default message throughput to assume for unseen bundles.
+    // Note that the default message size is implicitly defined as DEFAULT_MESSAGE_THROUGHPUT / DEFAULT_MESSAGE_RATE.
+    public static final double DEFAULT_MESSAGE_THROUGHPUT = 50000;
+
+    // The number of effective samples to keep for observing long term data.
+    public static final int NUM_LONG_SAMPLES = 1000;
+
+    // The number of effective samples to keep for observing short term data.
+    public static final int NUM_SHORT_SAMPLES = 10;
+
+    // Path to ZNode whose children contain ResourceQuota jsons.
+    public static final String RESOURCE_QUOTA_ZPATH = "/loadbalance/resource-quota/namespace";
+
+    // Path to ZNode containing TimeAverageBrokerData jsons for each broker.
+    public static final String TIME_AVERAGE_BROKER_ZPATH = "/loadbalance/broker-time-average";
+
+    // ZooKeeper Cache of the currently available active brokers.
+    // availableActiveBrokers.get() will return a set of the broker names without an http prefix.
+    private ZooKeeperChildrenCache availableActiveBrokers;
+
+    // Set of broker candidates to reuse so that object creation is avoided.
+    private final Set<String> brokerCandidateCache;
+
+    // ZooKeeper cache of the local broker data, stored in LoadManager.LOADBALANCE_BROKER_ROOT.
+    private ZooKeeperDataCache<LocalBrokerData> brokerDataCache;
+
+    // CETUS Zookeeper cache of the cetus broker data
+    private ZooKeeperDataCache<CetusBrokerData> cetusBrokerDataCache;
+
+    // Broker host usage object used to calculate system resource usage.
+    private BrokerHostUsage brokerHostUsage;
+
+    // Map from brokers to namespaces to the bundle ranges in that namespace assigned to that broker.
+    // Used to distribute bundles within a namespace evely across brokers.
+    private final Map<String, Map<String, Set<String>>> brokerToNamespaceToBundleRange;
+
+    // Path to the ZNode containing the LocalBrokerData json for this broker.
+    private String brokerZnodePath;
+
+    //CETUS 
+    private String cetusBrokerZnodePath;
+
+    // Strategy to use for splitting bundles.
+    private BundleSplitStrategy bundleSplitStrategy;
+
+    // Service configuration belonging to the pulsar service.
+    private ServiceConfiguration conf;
+
+    // The default bundle stats which are used to initialize historic data.
+    // This data is overriden after the bundle receives its first sample.
+    private final NamespaceBundleStats defaultStats;
+
+    // Used to filter brokers from being selected for assignment.
+    private final List<BrokerFilter> filterPipeline;
+
+    // Timestamp of last invocation of updateBundleData.
+    private long lastBundleDataUpdate;
+
+    // LocalBrokerData available before most recent update.
+    private LocalBrokerData lastData;
+
+    // Pipeline used to determine what namespaces, if any, should be unloaded.
+    private final List<LoadSheddingStrategy> loadSheddingPipeline;
+
+    private final CetusBundleUnloadingStrategy bundleUnloadingStrategy;
+
+    // Local data for the broker this is running on.
+    private LocalBrokerData localData;
+
+    // Client data for the clients connected to topics on this broker
+    //private ClientData clientData;
+
+    // CETUS Load Data for data available for each bundle
+    private final CetusLoadData cetusLoadData;
+
+    // Load data comprising data available for each broker.
+    //private final LoadData cetusLoadData.getLoadData();
+
+    // Used to determine whether a bundle is preallocated.
+    private final Map<String, String> preallocatedBundleToBroker;
+
+    public final Map<String, String> desiredBrokerForBundle;
+
+    // Strategy used to determine where new topics should be placed.
+    private ModularLoadManagerStrategy placementStrategy;
+
+    // Policies used to determine which brokers are available for particular namespaces.
+    private SimpleResourceAllocationPolicies policies;
+
+    // Pulsar service used to initialize this.
+    private PulsarService pulsar;
+
+    // Executor service used to regularly update broker data.
+    private final ScheduledExecutorService scheduler;
+
+    // ZooKeeper belonging to the pulsar service.
+    private ZooKeeper zkClient;
+
+    // check if given broker can load persistent/non-persistent topic
+    private final BrokerTopicLoadingPredicate brokerTopicLoadingPredicate;
+
+    private Map<String, String> brokerToFailureDomainMap;
+
+    // Cetus - Log Topic Migration Stats
+    private Map<String, TopicMigrationStats> topicMigrationStats;
+    private Multimap<String, Long> bundleUnloadTimes;
+    private Map<String, Long> bundleUnloadStartTime;
+    private ScheduledExecutorService bundleStatsPrintService;
+
+    private static final Deserializer<LocalBrokerData> loadReportDeserializer = (key, content) -> jsonMapper()
+        .readValue(content, LocalBrokerData.class);
+
+    private static final Deserializer<CetusBrokerData> cetusDeserializer = (key, content) -> jsonMapper()
+        .readValue(content, CetusBrokerData.class);
+
+    private long lastLoadSheddingTime;
+    private final long initTime;
+    private List<String> brokersList;
+    private int nextTargetBrokerIdx;
+
+    /**
+     * Initializes fields which do not depend on PulsarService. initialize(PulsarService) should subsequently be called.
+     */
+    public CetusPeriodicLoadManagerImpl() {
+        brokerCandidateCache = new HashSet<>();
+        brokerToNamespaceToBundleRange = new HashMap<>();
+        defaultStats = new NamespaceBundleStats();
+        filterPipeline = new ArrayList<>();
+        //cetusLoadData.getLoadData() = new LoadData();
+        loadSheddingPipeline = new ArrayList<>();
+        loadSheddingPipeline.add(new OverloadShedder());
+        bundleUnloadingStrategy = new CetusLoadShedder();
+        preallocatedBundleToBroker = new ConcurrentHashMap<>();
+        desiredBrokerForBundle = new ConcurrentHashMap<>();
+        scheduler = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("pulsar-modular-load-manager"));
+        this.brokerToFailureDomainMap = Maps.newHashMap();
+        // CETUS
+        //this.brokerToProducerConsumerMap = Maps.newHashMap();
+        this.cetusLoadData = new CetusLoadData();
+        this.topicMigrationStats = new HashMap<>();
+        this.bundleUnloadTimes = ArrayListMultimap.create();
+        this.bundleUnloadStartTime = new HashMap<>();
+        this.bundleStatsPrintService = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("broker-print"));
+        this.lastLoadSheddingTime = 0;
+        this.initTime = System.currentTimeMillis();
+        this.brokersList = null;
+        this.nextTargetBrokerIdx = -1;
+        
+        this.brokerTopicLoadingPredicate = new BrokerTopicLoadingPredicate() {
+            @Override
+                public boolean isEnablePersistentTopics(String brokerUrl) {
+                    final BrokerData brokerData = cetusLoadData.getLoadData().getBrokerData().get(brokerUrl.replace("http://", ""));
+                    return brokerData != null && brokerData.getLocalData() != null
+                        && brokerData.getLocalData().isPersistentTopicsEnabled();
+                }
+
+            @Override
+                public boolean isEnableNonPersistentTopics(String brokerUrl) {
+                    final BrokerData brokerData = cetusLoadData.getLoadData().getBrokerData().get(brokerUrl.replace("http://", ""));
+                    return brokerData != null && brokerData.getLocalData() != null
+                        && brokerData.getLocalData().isNonPersistentTopicsEnabled();
+                }
+        };
+    }
+
+    /**
+     * Initialize this load manager using the given PulsarService. Should be called only once, after invoking the
+     * default constructor.
+     *
+     * @param pulsar
+     *            The service to initialize with.
+     */
+    public void initialize(final PulsarService pulsar) {
+        this.pulsar = pulsar;
+        availableActiveBrokers = new ZooKeeperChildrenCache(pulsar.getLocalZkCache(),
+                LoadManager.LOADBALANCE_BROKERS_ROOT);
+        //scheduler.scheduleAtFixedRate(safeRun(() -> writeBrokerDataOnZooKeeper()), 0, 1000, TimeUnit.MILLISECONDS);
+        //scheduler.scheduleAtFixedRate(safeRun(() -> writeBundleDataOnZooKeeper()), 0, 1000, TimeUnit.MILLISECONDS);
+        availableActiveBrokers.registerListener(new ZooKeeperCacheListener<Set<String>>() {
+                @Override
+                public void onUpdate(String path, Set<String> data, Stat stat) {
+                if (log.isDebugEnabled()) {
+                log.debug("Update Received for path {}", path);
+                }
+                reapDeadBrokerPreallocations(data);
+                scheduler.submit(CetusPeriodicLoadManagerImpl.this::updateAll);
+                }
+                });
+
+        brokerDataCache = new ZooKeeperDataCache<LocalBrokerData>(pulsar.getLocalZkCache()) {
+            @Override
+                public LocalBrokerData deserialize(String key, byte[] content) throws Exception {
+                    return ObjectMapperFactory.getThreadLocal().readValue(content, LocalBrokerData.class);
+                }
+        };
+
+        //brokerDataCache.registerListener(this);
+        
+        cetusBrokerDataCache = new ZooKeeperDataCache<CetusBrokerData>(pulsar.getLocalZkCache()) {
+            @Override
+                public CetusBrokerData deserialize(String key, byte[] content) throws Exception {
+                    return ObjectMapperFactory.getThreadLocal().readValue(content, CetusBrokerData.class);
+                }
+        };
+        
+
+        cetusBrokerDataCache.registerListener(this);
+
+        if (SystemUtils.IS_OS_LINUX) {
+            brokerHostUsage = new LinuxBrokerHostUsageImpl(pulsar);
+        } else {
+            brokerHostUsage = new GenericBrokerHostUsageImpl(pulsar);
+        }
+
+        bundleSplitStrategy = new BundleSplitterTask(pulsar);
+
+        conf = pulsar.getConfiguration();
+
+        // Initialize the default stats to assume for unseen bundles (hard-coded for now).
+        defaultStats.msgThroughputIn = DEFAULT_MESSAGE_THROUGHPUT;
+        defaultStats.msgThroughputOut = DEFAULT_MESSAGE_THROUGHPUT;
+        defaultStats.msgRateIn = DEFAULT_MESSAGE_RATE;
+        defaultStats.msgRateOut = DEFAULT_MESSAGE_RATE;
+
+        lastData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+                pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
+        localData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+                pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
+        localData.setBrokerVersionString(pulsar.getBrokerVersion());
+        // configure broker-topic mode
+        lastData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
+        lastData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
+        localData.setPersistentTopicsEnabled(pulsar.getConfiguration().isEnablePersistentTopics());
+        localData.setNonPersistentTopicsEnabled(pulsar.getConfiguration().isEnableNonPersistentTopics());
+
+
+        placementStrategy = ModularLoadManagerStrategy.create(conf);
+        policies = new SimpleResourceAllocationPolicies(pulsar);
+        zkClient = pulsar.getZkClient();
+        filterPipeline.add(new BrokerVersionFilter());
+
+        refreshBrokerToFailureDomainMap();
+        // register listeners for domain changes
+        pulsar.getConfigurationCache().failureDomainListCache()
+            .registerListener((path, data, stat) -> scheduler.execute(() -> refreshBrokerToFailureDomainMap()));
+        pulsar.getConfigurationCache().failureDomainCache()
+            .registerListener((path, data, stat) -> scheduler.execute(() -> refreshBrokerToFailureDomainMap()));
+        startBundleStatsPrint();
+    }
+
+    /**
+     * Initialize this load manager.
+     *
+     * @param pulsar
+     *            Client to construct this manager from.
+     */
+    public CetusPeriodicLoadManagerImpl(final PulsarService pulsar) {
+        this();
+        initialize(pulsar);
+    }
+
+    void startBundleStatsPrint() {
+        log.info("Starting bundle stats service");
+        try {
+            FileHandler fh = new FileHandler("/home/tyler/pulsar/bundlestatslog.log");  
+            bundleStatsLog.addHandler(fh);
+            SimpleFormatter formatter = new SimpleFormatter();  
+            fh.setFormatter(formatter);  
+            bundleStatsPrintService.scheduleAtFixedRate(safeRun(() -> printBundleStats()), 100, 1000,TimeUnit.MILLISECONDS);
+        }
+        catch (Exception e) {
+            log.warn("Cannot setup bundle stats log");
+        }
+    }
+
+    void printBundleStats() {
+        //if (pulsar.getLeaderElectionService().isLeader()) {
+        try {
+            FileWriter unloadTimesFile = new FileWriter("/home/cetususer/pulsar/bundle_unload_times.json");
+            FileWriter unloadTopicTimesAvgFile = new FileWriter("/home/cetususer/pulsar/bundle_unload_avg.json");
+            FileWriter unloadTotalAvgFile = new FileWriter("/home/tyler/cetususer/bundle_unload_total_avg.json");
+            //bundleStatsLog.info("Bundle Stats: " +bundleUnloadTimes.toString());
+            Gson gson = new Gson();
+            String json = gson.toJson(bundleUnloadTimes.asMap());
+            log.info("Bundle Json: {}", json);
+            unloadTimesFile.write(json);
+            Map<String, Double> averages = new HashMap<>();
+            List<Double> averagesList = new ArrayList<>();
+            for(String key : bundleUnloadTimes.keySet()) {
+                Collection<Long> values = bundleUnloadTimes.get(key);
+                Double average = values.stream().mapToLong(val -> val).average().orElse(0.0);
+                averages.put(key, average);
+                averagesList.add(average);
+            }
+            //bundleStatsLog.info("Bundle Stats Avg: " +averages);
+            json = gson.toJson(averages);
+            unloadTopicTimesAvgFile.write(json);
+            Double totalAverage = averagesList.stream().mapToDouble(val -> val).average().orElse(0.0);
+            json = gson.toJson(totalAverage);
+            unloadTotalAvgFile.write(json);
+            unloadTimesFile.flush();
+            unloadTopicTimesAvgFile.flush();
+            unloadTotalAvgFile.flush();
+            bundleStatsLog.info("Bundle Stats Total Avg: " +totalAverage);
+
+
+        }
+        catch (Exception e) {
+        }
+
+
+
+        //}
+    } 
+
+    // Attempt to create a ZooKeeper path if it does not exist.
+    private static void createZPathIfNotExists(final ZooKeeper zkClient, final String path) throws Exception {
+        if (zkClient.exists(path, false) == null) {
+            try {
+                ZkUtils.createFullPathOptimistic(zkClient, path, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.PERSISTENT);
+            } catch (KeeperException.NodeExistsException e) {
+                // Ignore if already exists.
+            }
+        }
+    }
+
+    // For each broker that we have a recent load report, see if they are still alive
+    private void reapDeadBrokerPreallocations(Set<String> aliveBrokers) {
+        for ( String broker : cetusLoadData.getLoadData().getBrokerData().keySet() ) {
+            if ( !aliveBrokers.contains(broker)) {
+                if ( log.isDebugEnabled() ) {
+                    log.debug("Broker {} appears to have stopped; now reclaiming any preallocations", broker);
+                }
+                final Iterator<Map.Entry<String, String>> iterator = preallocatedBundleToBroker.entrySet().iterator();
+                while ( iterator.hasNext() ) {
+                    Map.Entry<String, String> entry = iterator.next();
+                    final String preallocatedBundle = entry.getKey();
+                    final String preallocatedBroker = entry.getValue();
+                    if ( broker.equals(preallocatedBroker) ) {
+                        if ( log.isDebugEnabled() ) {
+                            log.debug("Removing old preallocation on dead broker {} for bundle {}",
+                                    preallocatedBroker, preallocatedBundle);
+                        }
+                        iterator.remove();
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+        public Set<String> getAvailableBrokers() {
+            try {
+                return availableActiveBrokers.get();
+            } catch (Exception e) {
+                log.warn("Error when trying to get active brokers", e);
+                return cetusLoadData.getLoadData().getBrokerData().keySet();
+            }
+        }
+
+    // Attempt to local the data for the given bundle in ZooKeeper.
+    // If it cannot be found, return the default bundle data.
+    private BundleData getBundleDataOrDefault(final String bundle) {
+        BundleData bundleData = null;
+        try {
+            final String bundleZPath = getBundleDataZooKeeperPath(bundle);
+            final String quotaZPath = String.format("%s/%s", RESOURCE_QUOTA_ZPATH, bundle);
+            if (zkClient.exists(bundleZPath, null) != null) {
+                bundleData = readJson(zkClient.getData(bundleZPath, null, null), BundleData.class);
+            } else if (zkClient.exists(quotaZPath, null) != null) {
+                final ResourceQuota quota = readJson(zkClient.getData(quotaZPath, null, null), ResourceQuota.class);
+                bundleData = new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES);
+                // Initialize from existing resource quotas if new API ZNodes do not exist.
+                final TimeAverageMessageData shortTermData = bundleData.getShortTermData();
+                final TimeAverageMessageData longTermData = bundleData.getLongTermData();
+
+                shortTermData.setMsgRateIn(quota.getMsgRateIn());
+                shortTermData.setMsgRateOut(quota.getMsgRateOut());
+                shortTermData.setMsgThroughputIn(quota.getBandwidthIn());
+                shortTermData.setMsgThroughputOut(quota.getBandwidthOut());
+
+                longTermData.setMsgRateIn(quota.getMsgRateIn());
+                longTermData.setMsgRateOut(quota.getMsgRateOut());
+                longTermData.setMsgThroughputIn(quota.getBandwidthIn());
+                longTermData.setMsgThroughputOut(quota.getBandwidthOut());
+
+                // Assume ample history.
+                shortTermData.setNumSamples(NUM_SHORT_SAMPLES);
+                longTermData.setNumSamples(NUM_LONG_SAMPLES);
+            }
+        } catch (Exception e) {
+            log.warn("Error when trying to find bundle {} on zookeeper: {}", bundle, e);
+        }
+        if (bundleData == null) {
+            bundleData = new BundleData(NUM_SHORT_SAMPLES, NUM_LONG_SAMPLES, defaultStats);
+        }
+        return bundleData;
+    }
+
+    // Get the ZooKeeper path for the given bundle full name.
+    private static String getBundleDataZooKeeperPath(final String bundle) {
+        return BUNDLE_DATA_ZPATH + "/" + bundle;
+    }
+
+    // Use the Pulsar client to acquire the namespace bundle stats.
+    private Map<String, NamespaceBundleStats> getBundleStats() {
+        return pulsar.getBrokerService().getBundleStats();
+    }
+
+    // Use the thread local ObjectMapperFactory to read the given json data into an instance of the given class.
+    private static <T> T readJson(final byte[] data, final Class<T> clazz) throws IOException {
+        return ObjectMapperFactory.getThreadLocal().readValue(data, clazz);
+    }
+
+    private double percentChange(final double oldValue, final double newValue) {
+        if (oldValue == 0) {
+            if (newValue == 0) {
+                // Avoid NaN
+                return 0;
+            }
+            return Double.POSITIVE_INFINITY;
+        }
+        return 100 * Math.abs((oldValue - newValue) / oldValue);
+    }
+
+    // Determine if the broker data requires an update by delegating to the update condition.
+    private boolean needBrokerDataUpdate() {
+        final long updateMaxIntervalMillis = TimeUnit.MINUTES
+            .toMillis(conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
+        long timeSinceLastReportWrittenToZooKeeper = System.currentTimeMillis() - localData.getLastUpdate();
+        if (timeSinceLastReportWrittenToZooKeeper > updateMaxIntervalMillis) {
+            log.info("Writing local data to ZooKeeper because time since last update exceeded threshold of {} minutes",
+                    conf.getLoadBalancerReportUpdateMaxIntervalMinutes());
+            // Always update after surpassing the maximum interval.
+            return true;
+        }
+        final double maxChange = Math
+            .max(100.0 * (Math.abs(lastData.getMaxResourceUsage() - localData.getMaxResourceUsage())),
+                    Math.max(percentChange(lastData.getMsgRateIn() + lastData.getMsgRateOut(),
+                            localData.getMsgRateIn() + localData.getMsgRateOut()),
+                        Math.max(
+                            percentChange(lastData.getMsgThroughputIn() + lastData.getMsgThroughputOut(),
+                                localData.getMsgThroughputIn() + localData.getMsgThroughputOut()),
+                            percentChange(lastData.getNumBundles(), localData.getNumBundles()))));
+        if (maxChange > conf.getLoadBalancerReportUpdateThresholdPercentage()) {
+            log.info("Writing local data to ZooKeeper because maximum change {}% exceeded threshold {}%; " +
+                    "time since last report written is {} seconds", maxChange,
+                    conf.getLoadBalancerReportUpdateThresholdPercentage(), timeSinceLastReportWrittenToZooKeeper/1000.0);
+            return true;
+        }
+        return false;
+    }
+
+    // Update both the broker data and the bundle data.
+    public void updateAll() {
+        if (log.isDebugEnabled()) {
+            log.debug("Updating broker and bundle data for loadreport");
+        }
+        updateAllBrokerData();
+        updateBundleData();
+        updateLatencyData();
+        // broker has latest load-report: check if any bundle requires split
+        //checkNamespaceBundleSplit();
+    }
+
+    private void updateLatencyData() {
+        final Set<String> activeBrokers = getAvailableBrokers();
+        //final ConcurrentHashMap<String, CetusBrokerData> cetusBrokerDataMap = cetusLoadData.getCetusBrokerDataMap();
+        //final ConcurrentHashMap<String, CetusNetworkCoordinateData> cetusBundleDataMap = cetusLoadData.getCetusBundleDataMap();
+        for (String broker : activeBrokers) {
+            //log.info("Updating Latency Data : {}", broker);
+            try {
+                String key = String.format("%s/%s", CETUS_COORDINATE_DATA_ROOT, broker);
+                final CetusBrokerData cetusLocalData = cetusBrokerDataCache.get(key)
+                    .orElseThrow(KeeperException.NoNodeException::new);
+
+                if(cetusLoadData.getCetusBrokerDataMap().containsKey(broker)) {
+                    cetusLoadData.getCetusBrokerDataMap().put(broker, cetusLocalData);
+                }
+                else {
+                    String[] brokerIp = broker.split(":");
+                    String serfString = String.format("%s:%s", brokerIp[0], pulsar.getSerfBindPort());
+                    log.info("Joining Serf Node: {}", serfString);
+                    pulsar.getSerfClient().joinNode(brokerIp[0]);
+                    cetusLoadData.getCetusBrokerDataMap().put(broker, new CetusBrokerData(cetusLocalData)); 
+                }
+                
+                // Clearing the cetusLoadData bundle data map
+                // So that it is overwritten by recvd data
+                // TODO cetusLoadData.getCetusBundleDataMap().clear();
+
+                for(Map.Entry<String, CetusNetworkCoordinateData> entry : cetusLocalData.getBundleNetworkCoordinates().entrySet()) {
+                    //log.info("Putting bundle: {} into Bundle Map. BrokerPath: {}", entry.getKey(), cetusBrokerZnodePath);
+                    if(cetusLoadData.getCetusBundleDataMap().containsKey(entry.getKey())) {
+                        cetusLoadData.getCetusBundleDataMap().put(entry.getKey(), entry.getValue());
+                        //log.info("Cache Bundle Map Size: {}", cetusLoadData.getCetusBundleDataMap().size());
+                    }
+                    else {
+                        cetusLoadData.getCetusBundleDataMap().put(entry.getKey(), new CetusNetworkCoordinateData());
+                    }
+                }
+                for(Map.Entry<String, CetusNetworkCoordinateData> entry : cetusLoadData.getCetusBrokerDataMap().get(broker).getBundleNetworkCoordinates().entrySet()) {
+                    //log.info("Bundle: {} in Bundle Map. BrokerPath: {}", entry.getKey(), cetusBrokerZnodePath);
+                }
+
+            }
+            catch (NoNodeException ne){
+                log.debug("Couldn't get broker data, removing from map: {}", ne);
+                cetusLoadData.getCetusBrokerDataMap().remove(broker);
+                log.warn("[{}] broker load-report znode not present", broker, ne);
+            } 
+            catch (Exception e) {
+                log.warn("Error reading broker data from cache for broker - [{}], [{}]", broker, e.getMessage());
+            }
+
+        }
+        // Remove obsolete brokers.
+        for (final String broker : cetusLoadData.getCetusBrokerDataMap().keySet()) {
+            if (!activeBrokers.contains(broker)) {
+                cetusLoadData.getCetusBrokerDataMap().remove(broker);
+            }
+        }
+    }
+
+    // As the leader broker, update the broker data map in cetusLoadData.getLoadData() by querying ZooKeeper for the broker data put there
+    // by each broker via updateLocalBrokerData.
+    private void updateAllBrokerData() {
+        final Set<String> activeBrokers = getAvailableBrokers();
+        final Map<String, BrokerData> brokerDataMap = cetusLoadData.getLoadData().getBrokerData();
+        for (String broker : activeBrokers) {
+            try {
+                String key = String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, broker);
+                final LocalBrokerData localData = brokerDataCache.get(key)
+                    .orElseThrow(KeeperException.NoNodeException::new);
+
+                if (brokerDataMap.containsKey(broker)) {
+                    // Replace previous local broker data.
+                    brokerDataMap.get(broker).setLocalData(localData);
+                } else {
+                    // Initialize BrokerData object for previously unseen
+                    // brokers.
+                    brokerDataMap.put(broker, new BrokerData(localData));
+                }
+            } catch (NoNodeException ne) {
+                // it only happens if we update-brokerData before availableBrokerCache refreshed with latest data and
+                // broker's delete-znode watch-event hasn't updated availableBrokerCache
+                brokerDataMap.remove(broker);
+                log.warn("[{}] broker load-report znode not present", broker, ne);
+            } catch (Exception e) {
+                log.warn("Error reading broker data from cache for broker - [{}], [{}]", broker, e.getMessage());
+            }
+        }
+        // Remove obsolete brokers.
+        for (final String broker : brokerDataMap.keySet()) {
+            if (!activeBrokers.contains(broker)) {
+                brokerDataMap.remove(broker);
+            }
+        }
+    }
+
+    // As the leader broker, use the local broker data saved on ZooKeeper to update the bundle stats so that better load
+    // management decisions may be made.
+    private void updateBundleData() {
+        final Map<String, BundleData> bundleData = cetusLoadData.getLoadData().getBundleData();
+        // Iterate over the broker data.
+        for (Map.Entry<String, BrokerData> brokerEntry : cetusLoadData.getLoadData().getBrokerData().entrySet()) {
+            final String broker = brokerEntry.getKey();
+            final BrokerData brokerData = brokerEntry.getValue();
+            final Map<String, NamespaceBundleStats> statsMap = brokerData.getLocalData().getLastStats();
+
+            // Iterate over the last bundle stats available to the current
+            // broker to update the bundle data.
+            for (Map.Entry<String, NamespaceBundleStats> entry : statsMap.entrySet()) {
+                final String bundle = entry.getKey();
+                final NamespaceBundleStats stats = entry.getValue();
+                if (bundleData.containsKey(bundle)) {
+                    // If we recognize the bundle, add these stats as a new
+                    // sample.
+                    bundleData.get(bundle).update(stats);
+                } else {
+                    // Otherwise, attempt to find the bundle data on ZooKeeper.
+                    // If it cannot be found, use the latest stats as the first
+                    // sample.
+                    BundleData currentBundleData = getBundleDataOrDefault(bundle);
+                    currentBundleData.update(stats);
+                    bundleData.put(bundle, currentBundleData);
+                }
+            }
+
+            // Remove all loaded bundles from the preallocated maps.
+            final Map<String, BundleData> preallocatedBundleData = brokerData.getPreallocatedBundleData();
+            synchronized (preallocatedBundleData) {
+                for (String preallocatedBundleName : brokerData.getPreallocatedBundleData().keySet()) {
+                    if (brokerData.getLocalData().getBundles().contains(preallocatedBundleName)) {
+                        final Iterator<Map.Entry<String, BundleData>> preallocatedIterator = preallocatedBundleData.entrySet()
+                            .iterator();
+                        while (preallocatedIterator.hasNext()) {
+                            final String bundle = preallocatedIterator.next().getKey();
+
+                            if (bundleData.containsKey(bundle)) {
+                                preallocatedIterator.remove();
+                                preallocatedBundleToBroker.remove(bundle);
+                            }
+                        }
+                    }
+
+                    // This is needed too in case a broker which was assigned a bundle dies and comes back up.
+                    if ( preallocatedBundleToBroker.containsKey(preallocatedBundleName) ) {
+                        preallocatedBundleToBroker.remove(preallocatedBundleName);
+                    }
+                }
+            }
+
+            // Using the newest data, update the aggregated time-average data for the current broker.
+            brokerData.getTimeAverageData().reset(statsMap.keySet(), bundleData, defaultStats);
+            final Map<String, Set<String>> namespaceToBundleRange = brokerToNamespaceToBundleRange
+                .computeIfAbsent(broker, k -> new HashMap<>());
+            synchronized (namespaceToBundleRange) {
+                namespaceToBundleRange.clear();
+                LoadManagerShared.fillNamespaceToBundlesMap(statsMap.keySet(), namespaceToBundleRange);
+                LoadManagerShared.fillNamespaceToBundlesMap(preallocatedBundleData.keySet(), namespaceToBundleRange);
+            }
+        }
+    }
+
+    /**
+     * As any broker, disable the broker this manager is running on.
+     *
+     * @throws PulsarServerException
+     *             If ZooKeeper failed to disable the broker.
+     */
+    @Override
+        public void disableBroker() throws PulsarServerException {
+            if (StringUtils.isNotEmpty(brokerZnodePath)) {
+                try {
+                    pulsar.getZkClient().delete(brokerZnodePath, -1);
+                } catch (Exception e) {
+                    throw new PulsarServerException(e);
+                }
+            }
+        }
+
+
+    /**
+     * As the leader broker, select bundles for the namespace service to unload so that they may be reassigned to new
+     * brokers.
+     */
+
+    @Override
+        public synchronized void doLoadShedding() {
+            if (getAvailableBrokers().size() <= 1) {
+                log.info("Only 1 broker available: no load shedding will be performed");
+                return;
+            }
+
+            long currTime = System.currentTimeMillis();
+            /** 
+             * If this is first call to this function, 
+             */
+            if (currTime - initTime <= CetusPeriodicLoadManager.WARMUP_SECS*1000) {
+                log.debug("Warmup not done. Only {} seconds have passed since init.", (currTime - initTime)/1000);
+                return;
+            }
+
+            
+            if (this.brokersList == null) {
+                // Broker set hasn't been populated yet. 
+                // TODO IMPORTANT : This also means that once this list is populated, it cannot be changed
+                // We need to populate a sorted list of brokers that does not change
+                this.brokersList = new ArrayList<String>();
+                String selfUrl = pulsar.getBrokerServiceUrl();
+                for(Map.Entry<String, CetusBrokerData> brokerEntry : cetusLoadData.getCetusBrokerDataMap().entrySet()) {
+                    // Also exclude this broker (load manager)
+                    log.debug("PERIODIC_LB SELFURL : {} BROKERENTRY : {}", selfUrl, brokerEntry.getKey());
+                    if (selfUrl.equals(brokerEntry.getKey()))
+                        continue;
+                    this.brokersList.add(brokerEntry.getKey());
+                }
+                // Now sort the list to create a deterministic order
+                Collections.sort(this.brokersList);
+                this.nextTargetBrokerIdx = 0;
+            } else {
+                if (currTime - lastLoadSheddingTime <= CetusPeriodicLoadManager.PERIOD_SEC*1000) 
+                    return; // No load shedding needed at this time
+               
+                // The broker to select for all bundles is contained in this.nextTargetBrokerIdx
+                final Multimap<String, BrokerChange> bundlesToUnload = bundleUnloadingStrategy.findBundlesForUnloading(cetusLoadData.getCetusBrokerDataMap(), conf, pulsar.getWebServiceAddress());
+                log.info("Bundles to Unload: {}", bundlesToUnload.asMap());
+
+                String nextBroker = this.brokersList.get(this.nextTargetBrokerIdx);
+                bundlesToUnload.asMap().forEach((currBroker, brokerChanges) -> {
+                        brokerChanges.forEach(brokerChange -> {
+                            String bundle = brokerChange.bundle;
+                            final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
+                            final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
+                            if (!shouldAntiAffinityNamespaceUnload(namespaceName, bundleRange, currBroker)) {
+                            return;
+                            }
+                            // TODO Do we still need the recently unloaded condition ?
+                            if(!nextBroker.equals(currBroker))
+                            {
+                                long startTime = System.nanoTime();
+                                bundleUnloadStartTime.put(bundle, startTime);
+
+                                log.info("Marking desiredBroker for bundle {} = {}", bundle, nextBroker);
+                                this.desiredBrokerForBundle.put(bundle, nextBroker);
+                                log.info("desiredBrokerForBundle size = {}", this.desiredBrokerForBundle.size());
+                                log.info("desiredBrokerForBundle = {}", this.desiredBrokerForBundle);
+
+                                pulsar.getUnloadExecutor().execute(() -> performUnloading(currBroker, bundle, bundleRange, namespaceName, nextBroker));
+                            }
+                            });
+                        });
+                this.nextTargetBrokerIdx = (this.nextTargetBrokerIdx+1)%this.brokersList.size();
+            }
+        }
+
+    private void performUnloading(String broker, String bundle, String bundleRange, String namespaceName, String nextBroker) {
+        log.info("[Cetus Bundle Unload Strategy] Unloading bundle: {} from broker {} to broker {} at ts = {}", bundle, broker, nextBroker, System.currentTimeMillis());
+        String[] brokerSplit = nextBroker.split(":");
+        try {
+            pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespaceName, bundleRange, brokerSplit[0]);
+        } catch (PulsarServerException | PulsarAdminException e) {
+            log.warn("Error when trying to perform load shedding on {} for broker {}", bundle, broker, e);
+        }
+    }
+
+    public boolean shouldAntiAffinityNamespaceUnload(String namespace, String bundle, String currentBroker) {
+        try {
+            Optional<Policies> nsPolicies = pulsar.getConfigurationCache().policiesCache()
+                .get(path(POLICIES, namespace));
+            if (!nsPolicies.isPresent() || StringUtils.isBlank(nsPolicies.get().antiAffinityGroup)) {
+                return true;
+            }
+
+            synchronized (brokerCandidateCache) {
+                brokerCandidateCache.clear();
+                ServiceUnitId serviceUnit = pulsar.getNamespaceService().getNamespaceBundleFactory()
+                    .getBundle(namespace, bundle);
+                LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache,
+                        getAvailableBrokers(), brokerTopicLoadingPredicate);
+                return LoadManagerShared.shouldAntiAffinityNamespaceUnload(namespace, bundle, currentBroker, pulsar,
+                        brokerToNamespaceToBundleRange, brokerCandidateCache);
+            }
+
+        } catch (Exception e) {
+            log.warn("Failed to check anti-affinity namespace ownership for {}/{}/{}, {}", namespace, bundle,
+                    currentBroker, e.getMessage());
+
+        }
+        return true;
+    }
+
+    /**
+     * As the leader broker, attempt to automatically detect and split hot namespace bundles.
+     */
+    @Override
+        public void checkNamespaceBundleSplit() {
+
+            if (!conf.isLoadBalancerAutoBundleSplitEnabled() || pulsar.getLeaderElectionService() == null
+                    || !pulsar.getLeaderElectionService().isLeader()) {
+                return;
+            }
+            final boolean unloadSplitBundles = pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled();
+            synchronized (bundleSplitStrategy) {
+                final Set<String> bundlesToBeSplit = bundleSplitStrategy.findBundlesToSplit(cetusLoadData.getLoadData(), pulsar);
+                NamespaceBundleFactory namespaceBundleFactory = pulsar.getNamespaceService().getNamespaceBundleFactory();
+                for (String bundleName : bundlesToBeSplit) {
+                    try {
+                        final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundleName);
+                        final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundleName);
+                        if (!namespaceBundleFactory
+                                .canSplitBundle(namespaceBundleFactory.getBundle(namespaceName, bundleRange))) {
+                            continue;
+                        }
+                        log.info("Load-manager splitting bundle {} and unloading {}", bundleName, unloadSplitBundles);
+                        pulsar.getAdminClient().namespaces().splitNamespaceBundle(namespaceName, bundleRange,
+                                unloadSplitBundles);
+                        // Make sure the same bundle is not selected again.
+                        cetusLoadData.getLoadData().getBundleData().remove(bundleName);
+                        localData.getLastStats().remove(bundleName);
+                        pulsar.getCetusBrokerData().getBundleNetworkCoordinates().remove(bundleName);
+                        // Clear namespace bundle-cache
+                        this.pulsar.getNamespaceService().getNamespaceBundleFactory()
+                            .invalidateBundleCache(NamespaceName.get(namespaceName));
+                        deleteBundleDataFromZookeeper(bundleName);
+                        log.info("Successfully split namespace bundle {}", bundleName);
+                    } catch (Exception e) {
+                        log.error("Failed to split namespace bundle {}", bundleName, e);
+                    }
+                }
+            }
+
+        }
+
+    /**
+     * When the broker data ZooKeeper nodes are updated, update the broker data map.
+     */
+    @Override
+        public void onUpdate(final String path, final CetusBrokerData data, final Stat stat) {
+            if (!pulsar.getLeaderElectionService().isLeader()) {
+                return;
+            }
+
+            scheduler.submit(this::updateAll);
+        }
+
+// CETUS broker assignment selection - narrow down to specific singlular broker chosen
+// by our algorithm.
+public Optional<String> selectBrokerForAssignment(final ServiceUnitId serviceUnit) {
+    log.info("Selecting broker for assignment");
+    synchronized(brokerCandidateCache) {
+        final String bundle = serviceUnit.toString();
+        if(preallocatedBundleToBroker.containsKey(bundle)) {
+            return Optional.of(preallocatedBundleToBroker.get(bundle));
+        }
+        //Optional<String> broker = Optional.of("1");
+        final BundleData data = cetusLoadData.getLoadData().getBundleData().computeIfAbsent(bundle,
+                key -> getBundleDataOrDefault(bundle));
+        brokerCandidateCache.clear();
+
+        getBrokersMeetLatency(bundle, CetusPeriodicLoadManager.CETUS_LATENCY_BOUND_MS); //ms
+
+        //LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache, getAvailableBrokers(),
+        //brokerTopicLoadingPredicate);
+
+        /* Removing extra checks for now
+        // filter brokers which owns topic higher than threshold
+        LoadManagerShared.filterBrokersWithLargeTopicCount(brokerCandidateCache, cetusLoadData.getLoadData(),
+                conf.getLoadBalancerBrokerMaxTopics());
+
+        // distribute namespaces to domain and brokers according to anti-affinity-group
+        LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar, serviceUnit.toString(), brokerCandidateCache,
+                brokerToNamespaceToBundleRange, brokerToFailureDomainMap);
+        // distribute bundles evenly to candidate-brokers
+
+        LoadManagerShared.removeMostServicingBrokersForNamespace(serviceUnit.toString(), brokerCandidateCache,
+                brokerToNamespaceToBundleRange);
+        */
+        
+
+        /* NOT SURE WHY THIS PIECE OF CODE WAS PRESENT
+        for(Map.Entry<String, CetusBrokerData> brokerEntry : cetusLoadData.getCetusBrokerDataMap().entrySet()) {
+            if (brokerEntry.getKey().contains("d0"))
+                brokerCandidateCache.add(brokerEntry.getKey()); 
+        }*/
+
+        log.info("{} brokers being considered for assignment of {}", brokerCandidateCache.size(), bundle);
+
+        // Use the filter pipeline to finalize broker candidates.
+        try {
+            for (BrokerFilter filter : filterPipeline) {
+                filter.filter(brokerCandidateCache, data, cetusLoadData.getLoadData(), conf);
+            }
+        } catch ( BrokerFilterException x ) {
+            // restore the list of brokers to the full set
+            LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache, getAvailableBrokers(),
+                    brokerTopicLoadingPredicate);
+        }
+
+        if ( brokerCandidateCache.isEmpty() ) {
+            // restore the list of brokers to the full set
+            LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache, getAvailableBrokers(),
+                    brokerTopicLoadingPredicate);
+        }
+
+        // Choose a broker among the potentially smaller filtered list, when possible
+        Optional<String> broker = placementStrategy.selectBroker(brokerCandidateCache, data, cetusLoadData.getLoadData(), conf);
+        if (log.isDebugEnabled()) {
+            log.debug("Selected broker {} from candidate brokers {}", broker, brokerCandidateCache);
+        }
+
+        if (!broker.isPresent()) {
+            // No brokers available
+            return broker;
+        }
+
+        final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
+        final double maxUsage = cetusLoadData.getLoadData().getBrokerData().get(broker.get()).getLocalData().getMaxResourceUsage();
+        if (maxUsage > overloadThreshold) {
+            // All brokers that were in the filtered list were overloaded, so check if there is a better broker
+            LoadManagerShared.applyNamespacePolicies(serviceUnit, policies, brokerCandidateCache, getAvailableBrokers(),
+                    brokerTopicLoadingPredicate);
+            broker = placementStrategy.selectBroker(brokerCandidateCache, data, cetusLoadData.getLoadData(), conf);
+        }
+
+
+
+        cetusLoadData.getLoadData().getBrokerData().get(broker.get()).getPreallocatedBundleData().put(bundle, data);
+        preallocatedBundleToBroker.put(bundle, broker.get());
+
+        final String namespaceName = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
+        final String bundleRange = LoadManagerShared.getBundleRangeFromBundleName(bundle);
+        brokerToNamespaceToBundleRange.get(broker.get()).computeIfAbsent(namespaceName, k -> new HashSet<>())
+            .add(bundleRange);
+        log.info("Broker selected: {}", broker);
+        long endTime = System.nanoTime();
+        if(bundleUnloadStartTime.containsKey(bundle)) {
+            long startTime = bundleUnloadStartTime.get(bundle);
+            bundleUnloadTimes.put(bundle, (endTime - startTime));
+        }
+        return broker;
+
+    } 
+}
+
+private void getBrokersMeetLatency(final String bundle, int latencyReqMs) {
+    Optional<String> minDistanceBroker = Optional.of("");
+    String desiredBroker = this.desiredBrokerForBundle.get(bundle);
+    if (desiredBroker != null) {
+        brokerCandidateCache.add(desiredBroker); 
+        return;
+    }
+
+    log.info("Getting broker with least latency. Brokers to select from: {}", cetusLoadData.getCetusBrokerDataMap().size());
+    for(Map.Entry<String, CetusBrokerData> brokerEntry : cetusLoadData.getCetusBrokerDataMap().entrySet()) {
+        
+        if(cetusLoadData.getCetusBundleDataMap().containsKey(bundle)) {
+            log.info("Attempting to find closer broker: {} Distance: {}", brokerEntry.getKey(), CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()));
+
+            if((CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()) * 1000) < latencyReqMs) { // 1000 is seconds to millisecods
+                log.info("Bundle broker found: {}  Distance : {}", brokerEntry.getKey(), CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()));
+                brokerCandidateCache.add(brokerEntry.getKey()); 
+            }
+        }
+        else {
+            log.info("Choosing first broker available. Bundle Map Size: {}, bundle: {} brokerZnode: {} ", cetusLoadData.getCetusBundleDataMap().size(), bundle, cetusBrokerZnodePath);
+
+            cetusLoadData.getCetusBundleDataMap().put(bundle, new CetusNetworkCoordinateData());
+            if(cetusLoadData.getCetusBundleDataMap().containsKey(bundle)) {
+                log.info("Attempting to find closer broker: {} Distance: {}", brokerEntry.getKey(), CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()));
+
+                if(CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()) * 1000 < latencyReqMs) {
+                    //log.info("Bundle broker found: {}  Distance : {}", brokerEntry.getKey(), CoordinateUtil.calculateDistance(cetusLoadData.getCetusBundleDataMap().get(bundle).getProducerConsumerAvgCoordinate(), brokerEntry.getValue().getBrokerNwCoordinate()));
+                    brokerCandidateCache.add(brokerEntry.getKey()); 
+                }
+            }
+        }
+
+    }
+}
+
+/**
+ * As any broker, start the load manager.
+ *
+ * @throws PulsarServerException
+ *             If an unexpected error prevented the load manager from being started.
+ */
+@Override
+public void start() throws PulsarServerException {
+    try {
+        // Register the brokers in zk list
+        createZPathIfNotExists(zkClient, LoadManager.LOADBALANCE_BROKERS_ROOT);
+        createZPathIfNotExists(zkClient, CETUS_COORDINATE_DATA_ROOT);
+
+        String lookupServiceAddress = pulsar.getAdvertisedAddress() + ":" + conf.getWebServicePort();
+        brokerZnodePath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + lookupServiceAddress;
+        cetusBrokerZnodePath = CETUS_COORDINATE_DATA_ROOT + "/" + lookupServiceAddress;
+        final String timeAverageZPath = TIME_AVERAGE_BROKER_ZPATH + "/" + lookupServiceAddress;
+        pulsar.writeCoordinateDataOnZookeeper();
+        updateLocalBrokerData();
+        try {
+            ZkUtils.createFullPathOptimistic(zkClient, brokerZnodePath, localData.getJsonBytes(),
+                    ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+            ZkUtils.createFullPathOptimistic(zkClient, cetusBrokerZnodePath, pulsar.getCetusBrokerData().getJsonBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+        } catch (KeeperException.NodeExistsException e) {
+            long ownerZkSessionId = getBrokerZnodeOwner();
+            if (ownerZkSessionId != 0 && ownerZkSessionId != zkClient.getSessionId()) {
+                log.error("Broker znode - [{}] is own by different zookeeper-ssession {} ", brokerZnodePath,
+                        ownerZkSessionId);
+                throw new PulsarServerException(
+                        "Broker-znode owned by different zk-session " + ownerZkSessionId);
+            }
+            // Node may already be created by another load manager: in this case update the data.
+            zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);
+            zkClient.setData(cetusBrokerZnodePath, pulsar.getCetusBrokerData().getJsonBytes(), -1);
+        } catch (Exception e) {
+            // Catching exception here to print the right error message
+            log.error("Unable to create znode - [{}] for load balance on zookeeper ", brokerZnodePath, e);
+            throw e;
+        }
+        createZPathIfNotExists(zkClient, timeAverageZPath);
+        zkClient.setData(timeAverageZPath, (new TimeAverageBrokerData()).getJsonBytes(), -1);
+        updateAll();
+        lastBundleDataUpdate = System.currentTimeMillis();
+    } catch (Exception e) {
+        log.error("Unable to create znode - [{}] for load balance on zookeeper ", brokerZnodePath, e);
+        throw new PulsarServerException(e);
+    }
+}
+
+/**
+ * As any broker, stop the load manager.
+ *
+ * @throws PulsarServerException
+ *             If an unexpected error occurred when attempting to stop the load manager.
+ */
+@Override
+public void stop() throws PulsarServerException {
+    if (availableActiveBrokers != null) {
+        availableActiveBrokers.close();
+    }
+
+    if (brokerDataCache != null) {
+        brokerDataCache.close();
+        brokerDataCache.clear();
+    }
+    if(cetusBrokerDataCache != null) {
+        cetusBrokerDataCache.close();
+        cetusBrokerDataCache.clear();
+    }
+    scheduler.shutdown();
+}
+
+/**
+ * As any broker, retrieve the namespace bundle stats and system resource usage to update data local to this broker.
+ * @return
+ */
+@Override
+public LocalBrokerData updateLocalBrokerData() {
+    try {
+        final SystemResourceUsage systemResourceUsage = LoadManagerShared.getSystemResourceUsage(brokerHostUsage);
+        localData.update(systemResourceUsage, getBundleStats());
+    } catch (Exception e) {
+        log.warn("Error when attempting to update local broker data: {}", e);
+    }
+    return localData;
+}
+
+/**
+ * As any broker, write the local broker data to ZooKeeper.
+ */
+@Override
+public void writeBrokerDataOnZooKeeper() {
+    try {
+        updateLocalBrokerData();
+        //if (needBrokerDataUpdate()) {
+        localData.setLastUpdate(System.currentTimeMillis());
+        List<String> bundlesToRemove = new ArrayList<String>();
+        for (String b : pulsar.getCetusBrokerData().getBundleNetworkCoordinates().keySet()) {
+            if (!localData.getBundles().contains(b))
+                bundlesToRemove.add(b);
+        }
+        for (String bundleToRemove : bundlesToRemove) {
+            pulsar.getCetusBrokerData().getBundleNetworkCoordinates().remove(bundleToRemove);
+        }
+        log.info("Writing bundles to ZooKeeper: {}" ,localData.getBundles());
+        zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);
+
+        // Clear deltas.
+        localData.getLastBundleGains().clear();
+        localData.getLastBundleLosses().clear();
+
+        // Update previous data.
+        lastData.update(localData);
+        //log.info("Writing broker data to Zookeeper");
+        //}
+    } catch (Exception e) {
+        log.warn("Error writing broker data on ZooKeeper: {}", e);
+    }
+}
+
+
+@Override
+public Deserializer<LocalBrokerData> getLoadReportDeserializer() {
+    return loadReportDeserializer;
+}
+
+/**
+ * As the leader broker, write bundle data aggregated from all brokers to ZooKeeper.
+ */
+@Override
+public void writeBundleDataOnZooKeeper() {
+    updateBundleData();
+    // Write the bundle data to ZooKeeper.
+    for (Map.Entry<String, BundleData> entry : cetusLoadData.getLoadData().getBundleData().entrySet()) {
+        final String bundle = entry.getKey();
+        final BundleData data = entry.getValue();
+        try {
+            final String zooKeeperPath = getBundleDataZooKeeperPath(bundle);
+            createZPathIfNotExists(zkClient, zooKeeperPath);
+            zkClient.setData(zooKeeperPath, data.getJsonBytes(), -1);
+        } catch (Exception e) {
+            log.warn("Error when writing data for bundle {} to ZooKeeper: {}", bundle, e);
+        }
+    }
+    // Write the time average broker data to ZooKeeper.
+    for (Map.Entry<String, BrokerData> entry : cetusLoadData.getLoadData().getBrokerData().entrySet()) {
+        final String broker = entry.getKey();
+        final TimeAverageBrokerData data = entry.getValue().getTimeAverageData();
+        try {
+            final String zooKeeperPath = TIME_AVERAGE_BROKER_ZPATH + "/" + broker;
+            createZPathIfNotExists(zkClient, zooKeeperPath);
+            zkClient.setData(zooKeeperPath, data.getJsonBytes(), -1);
+            if (log.isDebugEnabled()) {
+                log.debug("Writing zookeeper report {}", data);
+            }
+        } catch (Exception e) {
+            log.warn("Error when writing time average broker data for {} to ZooKeeper: {}", broker, e);
+        }
+    }
+}
+
+private void deleteBundleDataFromZookeeper(String bundle) {
+    final String zooKeeperPath = getBundleDataZooKeeperPath(bundle);
+    try {
+        if (zkClient.exists(zooKeeperPath, null) != null) {
+            zkClient.delete(zooKeeperPath, -1);
+        }
+    } catch (Exception e) {
+        log.warn("Failed to delete bundle-data {} from zookeeper", bundle, e);
+    }
+}
+
+private long getBrokerZnodeOwner() {
+    try {
+        Stat stat = new Stat();
+        zkClient.getData(brokerZnodePath, false, stat);
+        return stat.getEphemeralOwner();
+    } catch (Exception e) {
+        log.warn("Failed to get stat of {}", brokerZnodePath, e);
+    }
+    return 0;
+}
+
+private void refreshBrokerToFailureDomainMap() {
+    if (!pulsar.getConfiguration().isFailureDomainsEnabled()) {
+        return;
+    }
+    final String clusterDomainRootPath = pulsar.getConfigurationCache().CLUSTER_FAILURE_DOMAIN_ROOT;
+    try {
+        synchronized (brokerToFailureDomainMap) {
+            Map<String, String> tempBrokerToFailureDomainMap = Maps.newHashMap();
+            for (String domainName : pulsar.getConfigurationCache().failureDomainListCache().get()) {
+                try {
+                    Optional<FailureDomain> domain = pulsar.getConfigurationCache().failureDomainCache()
+                        .get(clusterDomainRootPath + "/" + domainName);
+                    if (domain.isPresent()) {
+                        for (String broker : domain.get().brokers) {
+                            tempBrokerToFailureDomainMap.put(broker, domainName);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to get domain {}", domainName, e);
+                }
+            }
+            this.brokerToFailureDomainMap = tempBrokerToFailureDomainMap;
+        }
+        log.info("Cluster domain refreshed {}", brokerToFailureDomainMap);
+    } catch (Exception e) {
+        log.warn("Failed to get domain-list for cluster {}", e.getMessage());
+    }
+}
+
+private String getCoordinateZPath(final String broker) {
+    final String brokerZPath = "/cetus/coordinate-data/" + broker;
+    return brokerZPath;
+}
+
+/**
+ * 
+ * @param initiatorBrokerData
+ */
+private void checkReassignmentForLatency(final CetusBrokerData initiatorBrokerData) {
+    // currentBrokerNc <--- initiatorBrokerData.getBrokerNC()
+
+    /**
+     * for topic in initiatorBrokerData.topics()
+     *      currentLatency <-- calculateNetworkLatencies(currentBrokerNc, initiatorBrokerData[topic].producers, initiatorBrokerData[topic].consumers)
+     *                          + calculateBrokerLatency(initiatorBrokerData.getBrokerId(), topic)
+     *      candidates <-- findNearbyBrokers(topics, threshold)
+     *      for candidate in candidates
+     *             calculate new end to end latency as if topic was to be moved to candidate
+     *             if new latency < currentLatency
+     *                  migrate
+     */
+
+}
+
+private void latencyStatsUpdated(final CetusBrokerData nwCoordData) {
+    checkReassignmentForLatency(nwCoordData);
+}
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/PeriodicLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/PeriodicLoadManagerWrapper.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.loadbalance.LoadManager;
+import org.apache.pulsar.broker.loadbalance.CetusPeriodicLoadManager;
+import org.apache.pulsar.broker.loadbalance.ModularLoadManager;
+import org.apache.pulsar.broker.loadbalance.ResourceUnit;
+import org.apache.pulsar.common.naming.ServiceUnitId;
+import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
+import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
+import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
+
+/**
+ * Wrapper class allowing classes of instance PeriodicLoadManager to be compatible with the interface LoadManager.
+ */
+public class PeriodicLoadManagerWrapper implements LoadManager {
+    private CetusPeriodicLoadManager loadManager;
+
+    public PeriodicLoadManagerWrapper(final CetusPeriodicLoadManager loadManager) {
+        this.loadManager = loadManager;
+    }
+
+    @Override
+    public void disableBroker() throws Exception {
+        loadManager.disableBroker();
+    }
+
+    @Override
+    public void doLoadShedding() {
+        loadManager.doLoadShedding();
+    }
+
+    @Override
+    public void doNamespaceBundleSplit() {
+        loadManager.checkNamespaceBundleSplit();
+    }
+
+    @Override
+    public LoadManagerReport generateLoadReport() {
+        return loadManager.updateLocalBrokerData();
+    }
+
+    @Override
+    public Optional<ResourceUnit> getLeastLoaded(final ServiceUnitId serviceUnit) {
+        Optional<String> leastLoadedBroker = loadManager.selectBrokerForAssignment(serviceUnit);
+        if (leastLoadedBroker.isPresent()) {
+            return Optional.of(new SimpleResourceUnit(String.format("http://%s", leastLoadedBroker.get()),
+                    new PulsarResourceDescription()));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<Metrics> getLoadBalancingMetrics() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void initialize(final PulsarService pulsar) {
+        loadManager.initialize(pulsar);
+    }
+
+    @Override
+    public boolean isCentralized() {
+        return true;
+    }
+
+    @Override
+    public void setLoadReportForceUpdateFlag() {
+
+    }
+
+    @Override
+    public void start() throws PulsarServerException {
+        loadManager.start();
+    }
+
+    @Override
+    public void stop() throws PulsarServerException {
+        loadManager.stop();
+    }
+
+    @Override
+    public void writeLoadReportOnZookeeper() {
+        loadManager.writeBrokerDataOnZooKeeper();
+    }
+
+    @Override
+    public void writeResourceQuotasToZooKeeper() {
+        loadManager.writeBundleDataOnZooKeeper();
+    }
+
+    @Override
+    public Deserializer<? extends ServiceLookupData> getLoadReportDeserializer() {
+        return loadManager.getLoadReportDeserializer();
+    }
+
+    public CetusPeriodicLoadManager getLoadManager() {
+        return loadManager;
+    }
+
+    @Override
+    public Set<String> getAvailableBrokers() throws Exception {
+        return loadManager.getAvailableBrokers();
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -553,6 +553,11 @@ public class NamespaceService {
         return Optional.of(lookupAddress);
     }
 
+    public void unloadNamespaceBundle(NamespaceBundle bundle, String nextBroker) throws Exception {        
+        unloadNamespaceBundle(bundle, 1, TimeUnit.SECONDS, nextBroker);
+        LOG.info("Unloaded namespace bundle");
+    }
+
     public void unloadNamespaceBundle(NamespaceBundle bundle) throws Exception {
         
         unloadNamespaceBundle(bundle, 1, TimeUnit.SECONDS);
@@ -560,9 +565,13 @@ public class NamespaceService {
     }
 
     public void unloadNamespaceBundle(NamespaceBundle bundle, long timeout, TimeUnit timeoutUnit) throws Exception {
+        this.unloadNamespaceBundle(bundle, timeout, timeoutUnit, null);
+    }
+
+    public void unloadNamespaceBundle(NamespaceBundle bundle, long timeout, TimeUnit timeoutUnit, String nextBroker) throws Exception {
         bundlesCurrentlyUnloading.add(bundle.toString());
-        LOG.info("Currently Unloading: {}" , bundle.toString());
-        checkNotNull(ownershipCache.getOwnedBundle(bundle)).handleUnloadRequest(pulsar, timeout, timeoutUnit);
+        LOG.info("Currently Unloading: {} w/ nextBroker : {}" , bundle.toString(), nextBroker);
+        checkNotNull(ownershipCache.getOwnedBundle(bundle)).handleUnloadRequest(pulsar, timeout, timeoutUnit, nextBroker);
         pulsar.getCetusBrokerData().getBundleNetworkCoordinates().remove(bundle.toString());
         //LOG.info("Unloaded {}", bundle.toString());
         //bundlesCurrentlyUnloading.remove(bundle.toString());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -32,6 +32,8 @@ import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.CetusModularLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.impl.PeriodicLoadManagerWrapper;
+import org.apache.pulsar.broker.loadbalance.impl.CetusPeriodicLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
@@ -366,7 +368,12 @@ public class NamespaceService {
                        //if (LOG.isDebugEnabled()) {
                         LOG.info("Namespace bundle {} already owned by {} ", bundle, nsData);
                         //}
-                        String desiredBroker = ((CetusModularLoadManagerImpl)((ModularLoadManagerWrapper)loadManager.get()).getLoadManager()).desiredBrokerForBundle.get(bundle.toString());
+                        String desiredBroker = null;
+                        if (loadManager.get() instanceof CetusModularLoadManagerImpl) 
+                            desiredBroker = ((CetusModularLoadManagerImpl)((ModularLoadManagerWrapper)loadManager.get()).getLoadManager()).desiredBrokerForBundle.get(bundle.toString());
+                        else if (loadManager.get() instanceof CetusPeriodicLoadManagerImpl) 
+                            desiredBroker = ((CetusPeriodicLoadManagerImpl)((PeriodicLoadManagerWrapper)loadManager.get()).getLoadManager()).desiredBrokerForBundle.get(bundle.toString());
+                        LOG.info("Finally desired broker selected = {}", desiredBroker);
                         if (desiredBroker == null) {
                             future.complete(Optional.of(new LookupResult(nsData.get())));
                         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnedBundle.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnedBundle.java
@@ -92,6 +92,10 @@ public class OwnedBundle {
      * @throws Exception
      */
     public void handleUnloadRequest(PulsarService pulsar, long timeout, TimeUnit timeoutUnit) throws Exception {
+        this.handleUnloadRequest(pulsar, timeout, timeoutUnit, null);
+    }
+
+    public void handleUnloadRequest(PulsarService pulsar, long timeout, TimeUnit timeoutUnit, String nextBroker) throws Exception {
 
         long unloadBundleStartTime = System.nanoTime();
         LOG.info("Unloading bundle in owned bundle");
@@ -133,7 +137,7 @@ public class OwnedBundle {
 
             // close topics forcefully
             try {
-                unloadedTopics = pulsar.getBrokerService().unloadServiceUnit(bundle).get(timeout, timeoutUnit);
+                unloadedTopics = pulsar.getBrokerService().unloadServiceUnit(bundle, nextBroker).get(timeout, timeoutUnit);
             } catch (TimeoutException e) {
                 // ignore topic-close failure to unload bundle
                 LOG.error("Failed to close topics in namespace {} in {}/{} timeout", bundle.toString(), timeout,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -175,15 +175,18 @@ public class OwnershipCache {
     public CompletableFuture<Optional<NamespaceEphemeralData>> getOwnerAsync(NamespaceBundle suname) {
         String path = ServiceUnitZkUtils.path(suname);
 
+        LOG.info("Inside getOwnerAsync for bundle {}", suname);
         CompletableFuture<OwnedBundle> ownedBundleFuture = ownedBundlesCache.getIfPresent(path);
         if (ownedBundleFuture != null) {
             // Either we're the owners or we're trying to become the owner.
             return ownedBundleFuture.thenApply(serviceUnit -> {
                 // We are the owner of the service unit
+                LOG.info("ownedByndleFuture retrieved. We are the owner of service unit bundle {}", suname);
                 return Optional.of(serviceUnit.isActive() ? selfOwnerInfo : selfOwnerInfoDisabled);
             });
         }
 
+        LOG.info("We are NOT the owner of service unit bundle {}", suname);
         // If we're not the owner, we need to check if anybody else is
         return ownershipReadOnlyCache.getAsync(path);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/OwnershipCache.java
@@ -105,7 +105,14 @@ public class OwnershipCache {
      */
     private final NamespaceBundleFactory bundleFactory;
 
+    private boolean enableProactiveLoading;
+
     private class OwnedServiceUnitCacheLoader implements AsyncCacheLoader<String, OwnedBundle> {
+        private boolean enableProactiveLoading;
+
+        public OwnedServiceUnitCacheLoader (boolean enableProactiveLoading) {
+            this.enableProactiveLoading = enableProactiveLoading;
+        }
 
         @SuppressWarnings("deprecation")
         @Override
@@ -131,7 +138,7 @@ public class OwnershipCache {
                             }
                             ownershipReadOnlyCache.invalidate(namespaceBundleZNode);
                             future.complete(new OwnedBundle(
-                                    ServiceUnitZkUtils.suBundleFromPath(namespaceBundleZNode, bundleFactory)));
+                                    ServiceUnitZkUtils.suBundleFromPath(namespaceBundleZNode, bundleFactory), this.enableProactiveLoading, true));
                         } else {
                             // Failed to acquire lock
                             future.completeExceptionally(KeeperException.create(rc));
@@ -150,6 +157,7 @@ public class OwnershipCache {
      */
     public OwnershipCache(PulsarService pulsar, NamespaceBundleFactory bundleFactory) {
         this.ownerBrokerUrl = pulsar.getBrokerServiceUrl();
+        this.enableProactiveLoading = pulsar.getConfiguration().isProactiveLoadingEnabled();
         this.ownerBrokerUrlTls = pulsar.getBrokerServiceUrlTls();
         this.selfOwnerInfo = new NamespaceEphemeralData(ownerBrokerUrl, ownerBrokerUrlTls,
                 pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(), false);
@@ -160,7 +168,7 @@ public class OwnershipCache {
         this.ownershipReadOnlyCache = pulsar.getLocalZkCacheService().ownerInfoCache();
         // ownedBundlesCache contains all namespaces that are owned by the local broker
         this.ownedBundlesCache = Caffeine.newBuilder().executor(MoreExecutors.directExecutor())
-                .buildAsync(new OwnedServiceUnitCacheLoader());
+                .buildAsync(new OwnedServiceUnitCacheLoader(this.enableProactiveLoading));
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractDispatcherSingleActiveConsumer.java
@@ -171,6 +171,10 @@ public abstract class AbstractDispatcherSingleActiveConsumer {
         return (consumers.size() == 1) && Objects.equals(consumer, ACTIVE_CONSUMER_UPDATER.get(this));
     }
 
+    public CompletableFuture<Void> close(String nextBroker) {
+        return this.close();
+    }
+
     public CompletableFuture<Void> close() {
         IS_CLOSED_UPDATER.set(this, TRUE);
         return disconnectAllConsumers();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -379,7 +379,11 @@ public class Consumer {
 
     public void disconnect(String nextBroker) {
         log.info("Disconnecting consumer: {}", this);
-        cnx.closeConsumer(this);
+        if (nextBroker == null) {
+            cnx.closeConsumer(this);
+        } else {
+            cnx.closeConsumer(this, nextBroker);
+        }
         try {
             close();
         } catch (BrokerServiceException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -379,8 +379,6 @@ public class Consumer {
 
     public void disconnect(String nextBroker) {
         log.info("Disconnecting consumer: {}", this);
-        //if (nextBroker != null)
-        //    cnx.ctx().writeAndFlush(Commands.newNextBrokerHint(nextBroker));        
         cnx.closeConsumer(this);
         try {
             close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -71,6 +71,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Consumer {
     private final Subscription subscription;
+    private String nextBroker;
     private final SubType subType;
     private final ServerCnx cnx;
     private final String appId;
@@ -122,6 +123,7 @@ public class Consumer {
                     int maxUnackedMessages, ServerCnx cnx, String appId,
                     Map<String, String> metadata, boolean readCompacted, InitialPosition subscriptionInitialPosition) throws BrokerServiceException {
 
+        this.nextBroker = null;
         this.subscription = subscription;
         this.subType = subType;
         this.topicName = topicName;
@@ -372,7 +374,13 @@ public class Consumer {
     }
 
     public void disconnect() {
+        this.disconnect(null);
+    }
+
+    public void disconnect(String nextBroker) {
         log.info("Disconnecting consumer: {}", this);
+        //if (nextBroker != null)
+        //    cnx.ctx().writeAndFlush(Commands.newNextBrokerHint(nextBroker));        
         cnx.closeConsumer(this);
         try {
             close();
@@ -716,6 +724,10 @@ public class Consumer {
 
     public void setNetworkCoordinate(NetworkCoordinate coordinate) {
         this.coordinate = coordinate;
+    }
+
+    public void setNextBroker(String broker) {
+        this.nextBroker = broker;
     }
 
     private static final Logger log = LoggerFactory.getLogger(Consumer.class);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -429,15 +429,19 @@ public class Producer {
      *
      * @return Completable future indicating completion of producer close
      */
-    public CompletableFuture<Void> disconnect() {
+    public CompletableFuture<Void> disconnect(String nextBroker) {
         if (!closeFuture.isDone()) {
             log.info("Disconnecting producer: {}", this);
             cnx.ctx().executor().execute(() -> {
-                cnx.closeProducer(this);
+                cnx.closeProducer(this, nextBroker);
                 closeNow();
             });
         }
         return closeFuture;
+    }
+
+    public CompletableFuture<Void> disconnect() {
+        return this.disconnect(null);
     }
 
     public void updateRates() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1604,6 +1604,10 @@ public class ServerCnx extends PulsarHandler {
     }
 
     public void closeConsumer(Consumer consumer) {
+        this.closeConsumer(consumer, null);
+    }
+    
+    public void closeConsumer(Consumer consumer, String nextBroker) {
         // removes consumer-connection from map and send close command to consumer
         if (log.isDebugEnabled()) {
             log.debug("[{}] Removed consumer: {}", remoteAddress, consumer);
@@ -1611,7 +1615,10 @@ public class ServerCnx extends PulsarHandler {
         long consumerId = consumer.consumerId();
         consumers.remove(consumerId);
         if (remoteEndpointProtocolVersion >= v5.getNumber()) {
-            ctx.writeAndFlush(Commands.newCloseConsumer(consumerId, -1L));
+            if (nextBroker == null)
+                ctx.writeAndFlush(Commands.newCloseConsumer(consumerId, -1L));
+            else
+                ctx.writeAndFlush(Commands.newCloseConsumer(consumerId, -1L, nextBroker));
         } else {
             close();
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1580,15 +1580,24 @@ public class ServerCnx extends PulsarHandler {
     }
 
     public void closeProducer(Producer producer) {
+        this.closeProducer (producer, null);
+    }
+
+    public void closeProducer(Producer producer, String nextBroker) {
         // removes producer-connection from map and send close command to producer
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Removed producer: {}", remoteAddress, producer);
+            log.debug("[{}] Removed producer: {} - for nextBroker : {}", remoteAddress, producer, nextBroker);
         }
         long producerId = producer.getProducerId();
         producers.remove(producerId);
         if (remoteEndpointProtocolVersion >= v5.getNumber()) {
-            ctx.writeAndFlush(Commands.newCloseProducer(producerId, -1L));
+            if (nextBroker != null)
+                ctx.writeAndFlush(Commands.newCloseProducer(producerId, -1L, nextBroker));
+            else
+                ctx.writeAndFlush(Commands.newCloseProducer(producerId, -1L));
+            log.info("Closing producer by ctx.writeAndFlush");
         } else {
+            log.info("Closing producer by close()");
             close();
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1115,7 +1115,8 @@ public class ServerCnx extends PulsarHandler {
                             if (schema != null) {
                                 schemaVersionFuture = topic.addSchema(schema);
                             } else {
-                                schemaVersionFuture = topic.hasSchema().thenCompose((hasSchema) -> {
+                                /*schemaVersionFuture = topic.hasSchema().thenCompose((hasSchema) -> {
+                                        log.info("Done checking hasSchema for topic {}", topicName.toString());
                                         CompletableFuture<SchemaVersion> result = new CompletableFuture<>();
                                         if (hasSchema && schemaValidationEnforced) {
                                             result.completeExceptionally(new IncompatibleSchemaException(
@@ -1125,6 +1126,9 @@ public class ServerCnx extends PulsarHandler {
                                         }
                                         return result;
                                     });
+                                */
+                                schemaVersionFuture = new CompletableFuture<>();
+                                schemaVersionFuture.complete(SchemaVersion.Empty);
                             }
 
                             schemaVersionFuture.exceptionally(exception -> {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -98,6 +98,7 @@ public interface Topic {
     CompletableFuture<Void> checkReplication();
 
     CompletableFuture<Void> close();
+    CompletableFuture<Void> close(String nextBroker);
 
     void checkGC(int gcInterval);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
@@ -44,6 +44,7 @@ public interface NonPersistentDispatcher extends Dispatcher{
     boolean canUnsubscribe(Consumer consumer);
 
     CompletableFuture<Void> close() ;
+    CompletableFuture<Void> close(String nextBroker) ;
 
     CompletableFuture<Void> disconnectAllConsumers();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -146,6 +146,11 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
         return disconnectAllConsumers();
     }
 
+    public CompletableFuture<Void> close(String nextBroker) {
+        IS_CLOSED_UPDATER.set(this, TRUE);
+        return disconnectAllConsumers(nextBroker);
+    }
+
     @Override
     public synchronized void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
         if (!consumerSet.contains(consumer)) {
@@ -168,6 +173,16 @@ public class NonPersistentDispatcherMultipleConsumers extends AbstractDispatcher
             closeFuture.complete(null);
         } else {
             consumerList.forEach(Consumer::disconnect);
+        }
+        return closeFuture;
+    }
+
+    public synchronized CompletableFuture<Void> disconnectAllConsumers(String nextBroker) {
+        closeFuture = new CompletableFuture<>();
+        if (consumerList.isEmpty()) {
+            closeFuture.complete(null);
+        } else {
+            consumerList.forEach(c -> c.disconnect(nextBroker));
         }
         return closeFuture;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -140,4 +140,5 @@ public final class NonPersistentDispatcherSingleActiveConsumer extends AbstractD
     protected void cancelPendingRead() {
         // No-op
     }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -225,12 +225,16 @@ public class NonPersistentSubscription implements Subscription {
      */
     @Override
     public synchronized CompletableFuture<Void> disconnect() {
+        return this.disconnect(null);
+    }
+    
+    public synchronized CompletableFuture<Void> disconnect(String nextBroker) {
         CompletableFuture<Void> disconnectFuture = new CompletableFuture<>();
 
         // block any further consumers on this subscription
         IS_FENCED_UPDATER.set(this, TRUE);
 
-        (dispatcher != null ? dispatcher.close() : CompletableFuture.completedFuture(null)).thenCompose(v -> close())
+        (dispatcher != null ? dispatcher.close(nextBroker) : CompletableFuture.completedFuture(null)).thenCompose(v -> close())
                 .thenRun(() -> {
                     log.info("[{}][{}] Successfully disconnected and closed subscription", topicName, subName);
                     disconnectFuture.complete(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -526,7 +526,7 @@ public class NonPersistentTopic implements Topic {
         replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
         if (nextBroker != null) {
             producers.forEach(producer -> futures.add(producer.disconnect(nextBroker)));
-            subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));
+            subscriptions.forEach((s, sub) -> futures.add(sub.disconnect(nextBroker)));
         } else {
             producers.forEach(producer -> futures.add(producer.disconnect()));
             subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -789,6 +789,11 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return deleteFuture;
     }
 
+    @Override
+    public CompletableFuture<Void> close(String nextBroker) {
+        return this.close();
+    }
+
     /**
      * Close this topic - close all producers and subscriptions associated with this topic
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -483,6 +483,23 @@ public abstract class PulsarWebResource {
         this.validateBundleOwnership(bundle, authoritative, readOnly, null);
     }
 
+    public void redirectProactivelyOwnCall(String bundle, String nextBroker) {
+        if (nextBroker == null) {
+            log.error("nextBroker empty in redirectProactivelyOwnCall");
+            return;
+        }
+        log.info("Inside redirectProactivelyOwnCall bundle : {} nextBroker : {}", bundle, nextBroker);
+        try {
+            URI redirect = UriBuilder.fromUri(uri.getRequestUri()).host(nextBroker).replaceQueryParam("authoritative", true).build();
+
+            // Redirect
+            log.info("Redirecting the rest call to {}", redirect);
+            throw new WebApplicationException(Response.temporaryRedirect(redirect).build());
+        } catch (WebApplicationException wae) {
+            throw wae;
+        }
+    }
+
     public void validateBundleOwnership(NamespaceBundle bundle, boolean authoritative, boolean readOnly, String nextBroker)
             throws Exception {
         NamespaceService nsService = pulsar().getNamespaceService();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CetusBrokerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/CetusBrokerTest.java
@@ -132,10 +132,10 @@ public class CetusBrokerTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT); 
         assertTrue(pulsarClient.producersCount() == 2);
         assertTrue(pulsarClient.consumersCount() == 1);
-        long consumerId = consumer.getConsumerId();
-        long producerId = producer.getProducerId();
-        long producerId2 = producer2.getProducerId();
-        log.info("Got Consumer Id:"+consumerId); 
+        String consumerName = consumer.getConsumerName();
+        String producerName = producer.getProducerName();
+        String producerName2 = producer2.getProducerName();
+        log.info("Got Consumer Id:"+consumerName); 
         BrokerService brokerService = pulsar.getBrokerService();
            
         log.info("Got Service");
@@ -149,7 +149,7 @@ public class CetusBrokerTest extends BrokerTestBase {
         //URI uri = new URI(pulsarClientImpl.getConfiguration().getServiceUrl());
         //InetSocketAddress address = InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort());
         //ClientCnx cnx = pulsarClientImpl.getCnxPool().getConnection(address).getNow(null);
-        //ConsumerImpl<?> consumerImpl = cnx.getConsumer(consumerId);
+        //ConsumerImpl<?> consumerImpl = cnx.getConsumer(consumerName);
         //assertTrue(consumerImpl.getNetworkCoordinate().getAdjustment() != 0);
 
 
@@ -165,30 +165,30 @@ public class CetusBrokerTest extends BrokerTestBase {
     
         log.info("Got consumer network coordinate on other side of sleep");
 
-        ConcurrentHashMap<Long, NetworkCoordinate> consumerCoords = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getConsumerCoordinates();
+        ConcurrentHashMap<String, NetworkCoordinate> consumerCoords = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getConsumerCoordinates();
 
-        for(Map.Entry<Long, NetworkCoordinate> entry : consumerCoords.entrySet()) {
+        for(Map.Entry<String, NetworkCoordinate> entry : consumerCoords.entrySet()) {
             log.info("Consumer Id in Map: {}", entry.getKey());
         }
 
-        double adjustment = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getConsumerCoordinate(consumerId).getAdjustment();
+        double adjustment = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getConsumerCoordinate(consumerName).getAdjustment();
 
         assertTrue(adjustment != 0);
 
         log.info("Verified consumer adjustment is {}", adjustment);
 
-        adjustment = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerId).getAdjustment();
+        adjustment = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerName).getAdjustment();
 
         assertTrue(adjustment != 0);
 
         log.info("Verified producer adjustment is {}", adjustment);
 
-        adjustment = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerId2).getAdjustment();
+        adjustment = brokerService.pulsar().getCetusBrokerData().getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerName2).getAdjustment();
         assertTrue(adjustment != 0);
 
         log.info("Verified second producer adjustment is {}", adjustment);
 
-        //assertTrue(brokerService.getNetworkCoordinateCollector().getConsumerCoordinate(consumerId).getAdjustment() == 1);
+        //assertTrue(brokerService.getNetworkCoordinateCollector().getConsumerCoordinate(consumerName).getAdjustment() == 1);
 
         String brokerZkPath = "/cetus/coordinate-data" + "/" + brokerService.pulsar().getAdvertisedAddress() + ":" + brokerService.pulsar().getConfiguration().getWebServicePort();
 
@@ -234,11 +234,11 @@ public class CetusBrokerTest extends BrokerTestBase {
         log.info("Read back Zk info");
        
         if(cetusBrokerData != null) {
-            producerCoordinate = cetusBrokerData.getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerId);
+            producerCoordinate = cetusBrokerData.getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerName);
 
-            consumerCoordinate = cetusBrokerData.getBundleNetworkCoordinates().get(bundleName).getConsumerCoordinate(consumerId);        
+            consumerCoordinate = cetusBrokerData.getBundleNetworkCoordinates().get(bundleName).getConsumerCoordinate(consumerName);        
 
-            producerCoordinate2 = cetusBrokerData.getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerId2);
+            producerCoordinate2 = cetusBrokerData.getBundleNetworkCoordinates().get(bundleName).getProducerCoordinate(producerName2);
 
             //log.info("Producer Coordinate Adjustment: " +producerCoordinate.getAdjustment());
         }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -839,6 +839,8 @@ public interface Namespaces {
      */
     void unloadNamespaceBundle(String namespace, String bundle) throws PulsarAdminException;
 
+    void unloadNamespaceBundle(String namespace, String bundle, String nextBroker) throws PulsarAdminException;
+
     /**
      * Split namespace bundle
      *

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -841,6 +841,7 @@ public interface Namespaces {
 
     void unloadNamespaceBundle(String namespace, String bundle, String nextBroker) throws PulsarAdminException;
 
+    void proactivelyOwnNamespaceBundle(String namespace, String bundle, String nextBroker) throws PulsarAdminException;
     /**
      * Split namespace bundle
      *

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -434,6 +434,18 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
+    public void proactivelyOwnNamespaceBundle(String namespace, String bundle, String nextBroker) throws PulsarAdminException {
+        try {
+            NamespaceName ns = NamespaceName.get(namespace);
+            WebTarget path = namespacePath(ns, bundle, "proactivelyown");
+            if (nextBroker != null)
+                request(path.queryParam("nextBroker", nextBroker)).put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
     public void unloadNamespaceBundle(String namespace, String bundle) throws PulsarAdminException {
         this.unloadNamespaceBundle(namespace, bundle, null);
     }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -435,10 +435,18 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public void unloadNamespaceBundle(String namespace, String bundle) throws PulsarAdminException {
+        this.unloadNamespaceBundle(namespace, bundle, null);
+    }
+
+    @Override
+    public void unloadNamespaceBundle(String namespace, String bundle, String nextBroker) throws PulsarAdminException {
         try {
             NamespaceName ns = NamespaceName.get(namespace);
             WebTarget path = namespacePath(ns, bundle, "unload");
-            request(path).put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+            if (nextBroker != null)
+                request(path.queryParam("nextBroker", nextBroker)).put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+            else
+                request(path).put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusClientTestApp.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusClientTestApp.java
@@ -57,10 +57,11 @@ public class CetusClientTestApp {
     @Parameter(names = { "--inject-coordinates" }, description = "set this flag to inject coordinates" )
     boolean injectCoordinates;
 
+    @Parameter(names = { "--use-nc-proxy" }, description = "set this flag to use NC proxy instead of agent running on client" )
+    boolean useNcProxy;
+
     @Parameter(names = { "-nt", "--num-topics" }, description = "Number of topics to create")
     int numTopics;
-
-
 
     boolean tlsAllowInsecureConnection = false;
     boolean tlsEnableHostnameVerification = false;
@@ -82,6 +83,7 @@ public class CetusClientTestApp {
         this.numTopics = Integer.parseInt(properties.getProperty("numTopics", "1"));
         this.runEternally = Boolean.parseBoolean(properties.getProperty("runEternally", "false"));
         this.injectCoordinates = Boolean.parseBoolean(properties.getProperty("injectCoordinates", "false"));
+        this.useNcProxy = Boolean.parseBoolean(properties.getProperty("useNcProxy", "false"));
         this.tlsAllowInsecureConnection = Boolean
                 .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
         this.tlsEnableHostnameVerification = Boolean
@@ -107,6 +109,7 @@ public class CetusClientTestApp {
         clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
         clientBuilder.serviceUrl(serviceURL);
         clientBuilder.setUseSerfCoordinates(!injectCoordinates);
+        clientBuilder.setUseNetworkCoordinateProxy(useNcProxy);
         this.produceCommand.updateConfig(clientBuilder);
         this.consumeCommand.updateConfig(clientBuilder);
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusClientTestApp.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusClientTestApp.java
@@ -60,6 +60,10 @@ public class CetusClientTestApp {
     @Parameter(names = { "--use-nc-proxy" }, description = "set this flag to use NC proxy instead of agent running on client" )
     boolean useNcProxy;
 
+    @Parameter(names = { "--disable-next-broker-hint" }, description = "set this flag to disable the use of next broker hint" )
+    boolean disableNextBrokerHint;
+
+
     @Parameter(names = { "-nt", "--num-topics" }, description = "Number of topics to create")
     int numTopics;
 
@@ -110,6 +114,7 @@ public class CetusClientTestApp {
         clientBuilder.serviceUrl(serviceURL);
         clientBuilder.setUseSerfCoordinates(!injectCoordinates);
         clientBuilder.setUseNetworkCoordinateProxy(useNcProxy);
+        clientBuilder.setEnableNextBrokerHint(!disableNextBrokerHint);
         this.produceCommand.updateConfig(clientBuilder);
         this.consumeCommand.updateConfig(clientBuilder);
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusDroneClient.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusDroneClient.java
@@ -91,6 +91,9 @@ public class CetusDroneClient {
     @Parameter(names = { "--use-nc-proxy" }, description = "set this flag to use NC proxy instead of agent running on client" )
     boolean useNcProxy;
 
+    @Parameter(names = { "--disable-next-broker-hint" }, description = "set this flag to disable the use of next broker hint" )
+    boolean disableNextBrokerHint;
+
     boolean tlsAllowInsecureConnection = false;
     boolean tlsEnableHostnameVerification = false;
     String tlsTrustCertsFilePath = null;
@@ -131,6 +134,7 @@ public class CetusDroneClient {
         this.clientBuilder.serviceUrl(serviceURL);
         this.clientBuilder.setUseSerfCoordinates(true);
         this.clientBuilder.setUseNetworkCoordinateProxy(useNcProxy);
+        this.clientBuilder.setEnableNextBrokerHint(!disableNextBrokerHint);
     }
 
     private void produceMessages(String topic, String messagePayload, int produceRate) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusDroneClient.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusDroneClient.java
@@ -1,0 +1,277 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.cli;
+
+import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.FileInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.MalformedURLException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import org.apache.commons.io.HexDump;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.util.concurrent.RateLimiter;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+
+import com.google.common.collect.Lists;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+
+@Parameters(commandDescription = "Create a client for Cetus Drone swarm use-case")
+public class CetusDroneClient {
+    String authPluginClassName = null;
+    String authParams = null;
+    private String namespace = "pulsar-cluster-1/cetus";
+
+    @Parameter(names = { "--url" }, description = "Broker URL to which to connect.")
+    String serviceURL = null;
+
+    @Parameter(names = { "-h", "--help", }, help = true, description = "Show this help.")
+    boolean help;
+
+    @Parameter(names = { "-rf", "--run-forever" }, description = "set this flag to run forever" )
+    boolean runEternally;
+
+    @Parameter(names = {"-fr", "--follow-rate" }, description = "Msgs/sec published to follow leader topic")
+    int followRate;
+
+    @Parameter(names = {"-dr", "--detection-rate" }, description = "Msgs/sec published to detection topic")
+    int detectionRate;
+
+    @Parameter(names = { "-nt", "--num-topics" }, description = "Number of topics to create")
+    int numTopics;
+
+    @Parameter(names = { "-L", "--is-leader" }, description = "Is leader of swarm")
+    boolean isLeader;
+
+    @Parameter(names = { "-S", "--swarm-id" }, description = "Swarm ID")
+    int swarmId = 0;
+
+    boolean tlsAllowInsecureConnection = false;
+    boolean tlsEnableHostnameVerification = false;
+    String tlsTrustCertsFilePath = null;
+
+    JCommander commandParser;
+
+    ClientBuilder clientBuilder;
+
+    public CetusDroneClient(Properties properties) throws MalformedURLException {
+        this.serviceURL = StringUtils.isNotBlank(properties.getProperty("brokerServiceUrl"))
+                ? properties.getProperty("brokerServiceUrl") : properties.getProperty("webServiceUrl");
+        // fallback to previous-version serviceUrl property to maintain backward-compatibility
+        if (StringUtils.isBlank(this.serviceURL)) {
+            this.serviceURL = properties.getProperty("serviceUrl");
+        }
+        this.authPluginClassName = properties.getProperty("authPlugin");
+        this.authParams = properties.getProperty("authParams");
+        this.numTopics = Integer.parseInt(properties.getProperty("numTopics", "1"));
+        this.runEternally = Boolean.parseBoolean(properties.getProperty("runEternally", "false"));
+        this.tlsAllowInsecureConnection = Boolean
+                .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
+        this.tlsEnableHostnameVerification = Boolean
+                .parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
+        this.tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
+
+        this.commandParser = new JCommander();
+        commandParser.setProgramName("pulsar-client");
+        commandParser.addObject(this);
+    }
+
+    private void updateConfig() throws UnsupportedAuthenticationException, MalformedURLException {
+        this.clientBuilder = PulsarClient.builder();
+        if (isNotBlank(this.authPluginClassName)) {
+            this.clientBuilder.authentication(authPluginClassName, authParams);
+        }
+        this.clientBuilder.allowTlsInsecureConnection(this.tlsAllowInsecureConnection);
+        this.clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
+        this.clientBuilder.serviceUrl(serviceURL);
+        this.clientBuilder.setUseSerfCoordinates(true);
+    }
+
+    private void produceMessages(String topic, String messagePayload, int produceRate) {
+        int numMessagesSent = 0;
+        try {
+            PulsarClient client = clientBuilder.build();
+            Producer<byte[]> producer = client.newProducer().topic(topic).create();
+            System.out.println("Created new producer for topic "+topic);
+
+            RateLimiter limiter = (produceRate > 0) ? RateLimiter.create(produceRate) : null;
+            while(true) {
+                if (limiter != null) {
+                    limiter.acquire();
+                }
+
+                String ts = Long.toString(System.currentTimeMillis());
+                producer.send(messagePayload.getBytes());
+
+                numMessagesSent++;
+            }
+        }
+        catch (Exception e) {
+        }
+    }
+
+    private String interpretMessage(Message<byte[]> message, boolean displayHex) throws IOException {
+        byte[] msgData = message.getData();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (!displayHex) {
+            return new String(msgData);
+        } else {
+            HexDump.dump(msgData, 0, out, 0);
+            return new String(out.toByteArray());
+        }
+    }
+
+    private void consumeMessages(String topic) {
+        try{
+            int numMessagesConsumed = 0;
+            PulsarClient client = clientBuilder.build();
+            Consumer<byte[]> consumer = client.newConsumer().topic(topic).subscriptionName(topic).subscriptionType(SubscriptionType.Shared).subscribe();
+
+            int lastMsgId = -1;
+            while (true) {
+                Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
+                if (msg == null) {
+                } else {
+                    numMessagesConsumed += 1;
+                    String output = this.interpretMessage(msg, false);
+                    System.out.println("Reccvd message "+output);
+                    consumer.acknowledge(msg);
+                }
+            }
+            //client.close();
+        }
+        catch (Exception e) {
+        }
+    }
+
+    private String generateFullTopicName(String smallTopicName) {
+        String topicName = String.format("non-persistent://public/%s/%s", this.namespace, smallTopicName);
+        return topicName;
+    }
+
+    public int run(String[] args) {
+        try {
+            commandParser.parse(args);
+
+            if (isBlank(this.serviceURL)) {
+                commandParser.usage();
+                return -1;
+            }
+
+            if (help) {
+                commandParser.usage();
+                return 0;
+            }
+
+            try {
+                this.updateConfig(); // If the --url, --auth-plugin, or --auth-params parameter are not specified,
+                // it will default to the values passed in by the constructor
+            } catch (MalformedURLException mue) {
+                System.out.println("Unable to parse URL " + this.serviceURL);
+                commandParser.usage();
+                return -1;
+            } catch (UnsupportedAuthenticationException exp) {
+                System.out.println("Failed to load an authentication plugin");
+                commandParser.usage();
+                return -1;
+            }
+
+            ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("clients"));
+
+            String detectionTopic = generateFullTopicName("detections_"+swarmId);
+            if (isLeader) {
+                service.schedule(safeRun(() -> consumeMessages(detectionTopic)), 0, TimeUnit.MILLISECONDS);
+            } else {
+                service.schedule(safeRun(() -> produceMessages(detectionTopic, "DETECTION", detectionRate)), 0, TimeUnit.MILLISECONDS);
+            }
+
+            try {
+                System.out.println("Sleeping here for 5 secs");
+                Thread.sleep(5);
+            } catch (Exception e) {
+                System.err.println("Error while sleeping after all producer threads have been created");
+            }
+            
+            ScheduledExecutorService service2 = Executors.newSingleThreadScheduledExecutor(new DefaultThreadFactory("clients"));
+
+            String followLeaderTopic = generateFullTopicName("follow_leader_"+swarmId);
+            if (isLeader) {
+                service2.schedule(safeRun(() -> produceMessages(followLeaderTopic, "FOLLOW_LEADER", followRate)), 0, TimeUnit.MILLISECONDS);
+            } else {
+                service2.schedule(safeRun(() -> consumeMessages(followLeaderTopic)), 0, TimeUnit.MILLISECONDS);
+            }
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            if (e instanceof ParameterException) {
+                commandParser.usage();
+            } else {
+                e.printStackTrace();
+            }
+            return -1;
+        }
+
+        while(true) {
+            try {
+                Thread.sleep(1);
+            } catch (Exception e) {
+                System.err.println("Error while sleeping after all producer threads have been created");
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            System.out.println("Usage: cetus-client CONF_FILE_PATH [options] [command] [command options]");
+            System.exit(-1);
+        }
+        Properties properties = new Properties();
+
+        CetusDroneClient clientTool = new CetusDroneClient(properties);
+        int exit_code = clientTool.run(Arrays.copyOfRange(args, 1, args.length));
+
+        System.exit(exit_code);
+
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusDroneClient.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CetusDroneClient.java
@@ -88,6 +88,9 @@ public class CetusDroneClient {
     @Parameter(names = { "-S", "--swarm-id" }, description = "Swarm ID")
     int swarmId = 0;
 
+    @Parameter(names = { "--use-nc-proxy" }, description = "set this flag to use NC proxy instead of agent running on client" )
+    boolean useNcProxy;
+
     boolean tlsAllowInsecureConnection = false;
     boolean tlsEnableHostnameVerification = false;
     String tlsTrustCertsFilePath = null;
@@ -127,6 +130,7 @@ public class CetusDroneClient {
         this.clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
         this.clientBuilder.serviceUrl(serviceURL);
         this.clientBuilder.setUseSerfCoordinates(true);
+        this.clientBuilder.setUseNetworkCoordinateProxy(useNcProxy);
     }
 
     private void produceMessages(String topic, String messagePayload, int produceRate) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -321,4 +321,6 @@ public interface ClientBuilder extends Cloneable {
 
     ClientBuilder setUseNetworkCoordinateProxy(boolean useNcProxy);
 
+    ClientBuilder setEnableNextBrokerHint(boolean enableNextBrokerHint);
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -319,4 +319,6 @@ public interface ClientBuilder extends Cloneable {
 
     ClientBuilder setUseSerfCoordinates(boolean useSerfCoordinates);
 
+    ClientBuilder setUseNetworkCoordinateProxy(boolean useNcProxy);
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
@@ -379,4 +379,8 @@ public class ClientConfiguration implements Serializable {
         return confData;
     }
 
+    public void setEnableNextBrokerHint(boolean enableNextBrokerHint) {
+        confData.setEnableNextBrokerHint(enableNextBrokerHint);
+    }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
@@ -366,6 +366,10 @@ public class ClientConfiguration implements Serializable {
         confData.setUseSerfCoordinates(useSerfCoordinates);
     }
 
+    public void setUseNetworkCoordinateProxy(boolean useNcProxy) {
+        confData.setUseNetworkCoordinateProxy(useNcProxy);
+    }
+
     public ClientConfiguration setServiceUrl(String serviceUrl) {
         confData.setServiceUrl(serviceUrl);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -54,12 +54,14 @@ public class BinaryProtoLookupService implements LookupService {
     protected volatile InetSocketAddress serviceAddress;
     private final boolean useTls;
     private final ExecutorService executor;
+    private final boolean enableNextBrokerHint;
 
-    public BinaryProtoLookupService(PulsarClientImpl client, String serviceUrl, boolean useTls, ExecutorService executor)
+    public BinaryProtoLookupService(PulsarClientImpl client, String serviceUrl, boolean useTls, ExecutorService executor, boolean enableNextBrokerHint)
             throws PulsarClientException {
         this.client = client;
         this.useTls = useTls;
         this.executor = executor;
+        this.enableNextBrokerHint = enableNextBrokerHint;
         updateServiceUrl(serviceUrl);
     }
 
@@ -86,7 +88,7 @@ public class BinaryProtoLookupService implements LookupService {
      * @return broker-socket-address that serves given topic
      */
     public CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> getBroker(TopicName topicName) {
-        return findBroker(serviceAddress, true, topicName);
+        return findBroker(serviceAddress, this.enableNextBrokerHint, topicName);
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BinaryProtoLookupService.java
@@ -86,7 +86,7 @@ public class BinaryProtoLookupService implements LookupService {
      * @return broker-socket-address that serves given topic
      */
     public CompletableFuture<Pair<InetSocketAddress, InetSocketAddress>> getBroker(TopicName topicName) {
-        return findBroker(serviceAddress, false, topicName);
+        return findBroker(serviceAddress, true, topicName);
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -195,6 +195,12 @@ public class ClientBuilderImpl implements ClientBuilder {
         return this;
     }
 
+    @Override
+    public ClientBuilder setUseNetworkCoordinateProxy(boolean useNcProxy) {
+        conf.setUseNetworkCoordinateProxy(useNcProxy);
+        return this;
+    }
+
     public ClientConfigurationData getClientConfigurationData() {
         return conf;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -201,6 +201,12 @@ public class ClientBuilderImpl implements ClientBuilder {
         return this;
     }
 
+    @Override
+    public ClientBuilder setEnableNextBrokerHint(boolean enableNextBrokerHint) {
+        conf.setEnableNextBrokerHint(enableNextBrokerHint);
+        return this;
+    }
+
     public ClientConfigurationData getClientConfigurationData() {
         return conf;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -686,11 +686,14 @@ public class ClientCnx extends PulsarHandler {
 
     @Override
     protected void handleCloseConsumer(CommandCloseConsumer closeConsumer) {
-        log.info("[{}] Broker notification of Closed consumer: {}", remoteAddress, closeConsumer.getConsumerId());
+        log.info("[{}] Broker notification of Closed consumer: {}, {}", remoteAddress, closeConsumer.getConsumerId(), closeConsumer.hasNextBroker());
         final long consumerId = closeConsumer.getConsumerId();
         ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
-            consumer.connectionClosed(this);
+            if (closeConsumer.hasNextBroker())
+                consumer.connectionClosed(this, closeConsumer.getNextBroker());
+            else
+                consumer.connectionClosed(this);
         } else {
             log.warn("Consumer with id {} not found while closing consumer ", consumerId);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -671,11 +671,14 @@ public class ClientCnx extends PulsarHandler {
 
     @Override
     protected void handleCloseProducer(CommandCloseProducer closeProducer) {
-        log.info("[{}] Broker notification of Closed producer: {}", remoteAddress, closeProducer.getProducerId());
+        log.info("[{}] Broker notification of Closed producer: {}, {}", remoteAddress, closeProducer.getProducerId(), closeProducer.hasNextBroker());
         final long producerId = closeProducer.getProducerId();
         ProducerImpl<?> producer = producers.get(producerId);
         if (producer != null) {
-            producer.connectionClosed(this);
+            if (closeProducer.hasNextBroker())
+                producer.connectionClosed(this, closeProducer.getNextBroker());
+            else
+                producer.connectionClosed(this);
         } else {
             log.warn("Producer with id {} not found while closing producer ", producerId);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1697,6 +1697,19 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         this.connectionHandler.connectionClosed(cnx);
     }
 
+    void connectionClosed(ClientCnx cnx, String nextBroker) {
+        String newServiceUrl = "pulsar://"+nextBroker+":6650";
+        log.info("Updating serviceUrl to {}", newServiceUrl);
+        try {
+            this.getClient().getLookup().updateServiceUrl(newServiceUrl);
+        } catch (PulsarClientException e) {
+            log.error("Error updating the service url to {}", newServiceUrl);
+        }
+        this.closedTime = System.currentTimeMillis();
+        log.info("Closed Time: {}", this.closedTime);
+        this.connectionHandler.connectionClosed(cnx);
+    }
+
     @VisibleForTesting
         public ClientCnx getClientCnx() {
             return this.connectionHandler.getClientCnx();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -291,13 +291,18 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     void startCoordinateProviderService() {
         int interval = 1000;
         log.info("Running Coordinate Service");
-        //coordinateProviderService.schedule(safeRun(() -> joinSerfCluster()), interval, TimeUnit.MILLISECONDS);
-        //if(!client.getIsJoinedToSerfCluster()) {
-        //    joinSerfCluster();
-        //}
+
+        if(!client.getConfiguration().isUseNetworkCoordinateProxy()) {
+            //coordinateProviderService.schedule(safeRun(() -> joinSerfCluster()), interval, TimeUnit.MILLISECONDS);
+            if(!client.getIsJoinedToSerfCluster()) {
+                joinSerfCluster();
+            }
+        }
 
         coordinateProviderService.scheduleAtFixedRate(safeRun(() -> sendCoordinate()), interval, interval, TimeUnit.MILLISECONDS);
-        coordinateProviderService.scheduleAtFixedRate(safeRun(() -> updateSerfGateway()), interval, interval, TimeUnit.MILLISECONDS);
+        if(client.getConfiguration().isUseNetworkCoordinateProxy()) {
+            coordinateProviderService.scheduleAtFixedRate(safeRun(() -> updateSerfGateway()), interval, interval, TimeUnit.MILLISECONDS);
+        }
         clientDownTimeLoggerService.scheduleAtFixedRate(safeRun(() -> writeDownTimes()), 5000, 5000, TimeUnit.MILLISECONDS);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -266,9 +266,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         int interval = 1000;
 	    log.info("Running Coordinate Service");
         //coordinateProviderService.schedule(safeRun(() -> joinSerfCluster()), interval, TimeUnit.MILLISECONDS);
-        if(!client.getIsJoinedToSerfCluster()) {
-	        joinSerfCluster();
-        }
+//        if(!client.getIsJoinedToSerfCluster()) {
+//	        joinSerfCluster();
+        //}
 	
         coordinateProviderService.scheduleAtFixedRate(safeRun(() -> sendCoordinate()), interval, interval, TimeUnit.MILLISECONDS);
         coordinateProviderService.scheduleAtFixedRate(safeRun(() -> updateSerfGateway()), interval, interval, TimeUnit.MILLISECONDS);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1588,6 +1588,20 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     void connectionClosed(ClientCnx cnx) {
+        this.getClient().getLookup();
+        this.closedTime = System.currentTimeMillis();
+        log.info("Closed Time: {}", this.closedTime);
+        this.connectionHandler.connectionClosed(cnx);
+    }
+
+    void connectionClosed(ClientCnx cnx, String nextBroker) {
+        String newServiceUrl = "pulsar://"+nextBroker+":6650";
+        log.info("Updating serviceUrl to {}", newServiceUrl);
+        try {
+            this.getClient().getLookup().updateServiceUrl(newServiceUrl);
+        } catch (PulsarClientException e) {
+            log.error("Error updating the service url to {}", newServiceUrl);
+        }
         this.closedTime = System.currentTimeMillis();
         log.info("Closed Time: {}", this.closedTime);
         this.connectionHandler.connectionClosed(cnx);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -264,15 +264,18 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     void startCoordinateProviderService() {
         int interval = 1000;
-	    log.info("Running Coordinate Service");
-        //coordinateProviderService.schedule(safeRun(() -> joinSerfCluster()), interval, TimeUnit.MILLISECONDS);
-//        if(!client.getIsJoinedToSerfCluster()) {
-//	        joinSerfCluster();
-        //}
-	
+        if(!client.getConfiguration().isUseNetworkCoordinateProxy()) {
+            //coordinateProviderService.schedule(safeRun(() -> joinSerfCluster()), interval, TimeUnit.MILLISECONDS);
+            if(!client.getIsJoinedToSerfCluster()) {
+                joinSerfCluster();
+            }
+        }
+
         coordinateProviderService.scheduleAtFixedRate(safeRun(() -> sendCoordinate()), interval, interval, TimeUnit.MILLISECONDS);
-        coordinateProviderService.scheduleAtFixedRate(safeRun(() -> updateSerfGateway()), interval, interval, TimeUnit.MILLISECONDS);
-	clientDownTimeLoggerService.scheduleAtFixedRate(safeRun(() -> writeDownTimes()), 5000, 5000, TimeUnit.MILLISECONDS);
+        if(client.getConfiguration().isUseNetworkCoordinateProxy()) {
+            coordinateProviderService.scheduleAtFixedRate(safeRun(() -> updateSerfGateway()), interval, interval, TimeUnit.MILLISECONDS);
+        }
+        clientDownTimeLoggerService.scheduleAtFixedRate(safeRun(() -> writeDownTimes()), 5000, 5000, TimeUnit.MILLISECONDS);
     }
 
     public void writeDownTimes() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -106,12 +106,12 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     private static final String SERF_RPC_IP = "0.0.0.0";
-    private static final int SERF_RPC_PORT = 7374;
+    private static final int SERF_RPC_PORT = 7373;
     private static String serfRpcIp;
     private static int serfRpcPort;
 
     private static final String SERF_BIND_IP = "0.0.0.0";
-    private static final int SERF_BIND_PORT = 8000;
+    private static final int SERF_BIND_PORT = 8085;
     private static String serfBindIp;
     private static int serfBindPort;
 
@@ -174,10 +174,7 @@ public class PulsarClientImpl implements PulsarClient {
         producers = Maps.newIdentityHashMap();
         consumers = Maps.newIdentityHashMap();
         try {
-            //InetAddress IAddress = InetAddress.getLocalHost();
-            //this.nodeName = IAddress.getHostName();
             BufferedReader br = new BufferedReader(new FileReader("/etc/nodeName"));
-            
             this.nodeName = br.readLine();
             log.info("Node Name: {}", this.nodeName);
 
@@ -214,14 +211,10 @@ public class PulsarClientImpl implements PulsarClient {
         }
         
         state.set(State.Open);
-        joinSerfCluster();
     }
 
     public ClientConfigurationData getConfiguration() {
         return conf;
-    }
-
-    protected void joinSerfCluster() {
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -183,8 +183,8 @@ public class PulsarClientImpl implements PulsarClient {
 
             br = new BufferedReader(new FileReader("/etc/outboundEthIp"));
 	        this.serfBindIp = this.serfRpcIp = br.readLine();
-	        this.serfBindPort = 8000;
-	        this.serfRpcPort =  7374;
+	        this.serfBindPort = 8085;
+	        this.serfRpcPort =  7373;
             this.isJoinedToSerfCluster = false;
             /*
 	        final Runtime rt = Runtime.getRuntime();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -62,6 +62,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     // Cetus Inject Coordinate
     private boolean useSerfCoordinates = true;
     private boolean useNetworkCoordinateProxy = false;
+    private boolean enableNextBrokerHint = true;
  
     public ClientConfigurationData clone() {
         try {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -61,6 +61,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
    
     // Cetus Inject Coordinate
     private boolean useSerfCoordinates = true;
+    private boolean useNetworkCoordinateProxy = false;
  
     public ClientConfigurationData clone() {
         try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -85,6 +85,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetNetworkCoordinate;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetNetworkCoordinateResponse;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSerfJoin;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandNextBrokerHint;
 //***************************************************************
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -446,6 +447,19 @@ public class Commands {
         return res;
     }
 
+    public static ByteBuf newCloseProducer(long producerId, long requestId, String nextBroker) {
+        CommandCloseProducer.Builder closeProducerBuilder = CommandCloseProducer.newBuilder();
+        closeProducerBuilder.setProducerId(producerId);
+        closeProducerBuilder.setRequestId(requestId);
+        closeProducerBuilder.setNextBroker(nextBroker);
+        CommandCloseProducer closeProducer = closeProducerBuilder.build();
+        ByteBuf res = serializeWithSize(
+                BaseCommand.newBuilder().setType(Type.CLOSE_PRODUCER).setCloseProducer(closeProducerBuilder));
+        closeProducerBuilder.recycle();
+        closeProducer.recycle();
+        return res;
+    }
+
     @VisibleForTesting
     public static ByteBuf newProducer(String topic, long producerId, long requestId, String producerName,
                 Map<String, String> metadata) {
@@ -793,6 +807,17 @@ public class Commands {
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.SERF_JOIN).setSerfJoin(commandSerfJoin));
         commandSerfJoinBuilder.recycle();
         commandSerfJoin.recycle();
+        return res;
+    }
+
+    public static ByteBuf newNextBrokerHint(String nextBroker) {
+        CommandNextBrokerHint.Builder builder = CommandNextBrokerHint.newBuilder();
+        builder.setAddress(nextBroker);
+
+        CommandNextBrokerHint cmd = builder.build();
+        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.NEXT_BROKER_HINT).setNextBrokerHint(cmd));
+        builder.recycle();
+        cmd.recycle();
         return res;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -85,7 +85,6 @@ import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetNetworkCoordinate;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandGetNetworkCoordinateResponse;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSerfJoin;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandNextBrokerHint;
 //***************************************************************
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
@@ -807,17 +806,6 @@ public class Commands {
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.SERF_JOIN).setSerfJoin(commandSerfJoin));
         commandSerfJoinBuilder.recycle();
         commandSerfJoin.recycle();
-        return res;
-    }
-
-    public static ByteBuf newNextBrokerHint(String nextBroker) {
-        CommandNextBrokerHint.Builder builder = CommandNextBrokerHint.newBuilder();
-        builder.setAddress(nextBroker);
-
-        CommandNextBrokerHint cmd = builder.build();
-        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.NEXT_BROKER_HINT).setNextBrokerHint(cmd));
-        builder.recycle();
-        cmd.recycle();
         return res;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -423,6 +423,19 @@ public class Commands {
         return res;
     }
 
+    public static ByteBuf newCloseConsumer(long consumerId, long requestId, String nextBroker) {
+        CommandCloseConsumer.Builder closeConsumerBuilder = CommandCloseConsumer.newBuilder();
+        closeConsumerBuilder.setConsumerId(consumerId);
+        closeConsumerBuilder.setRequestId(requestId);
+        closeConsumerBuilder.setNextBroker(nextBroker);
+        CommandCloseConsumer closeConsumer = closeConsumerBuilder.build();
+        ByteBuf res = serializeWithSize(
+                BaseCommand.newBuilder().setType(Type.CLOSE_CONSUMER).setCloseConsumer(closeConsumer));
+        closeConsumerBuilder.recycle();
+        closeConsumer.recycle();
+        return res;
+    }
+
     public static ByteBuf newReachedEndOfTopic(long consumerId) {
         CommandReachedEndOfTopic.Builder reachedEndOfTopicBuilder = CommandReachedEndOfTopic.newBuilder();
         reachedEndOfTopicBuilder.setConsumerId(consumerId);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -18228,6 +18228,10 @@ public final class PulsarApi {
     // required uint64 request_id = 2;
     boolean hasRequestId();
     long getRequestId();
+    
+    // optional string next_broker = 3;
+    boolean hasNextBroker();
+    String getNextBroker();
   }
   public static final class CommandCloseProducer extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -18284,9 +18288,42 @@ public final class PulsarApi {
       return requestId_;
     }
     
+    // optional string next_broker = 3;
+    public static final int NEXT_BROKER_FIELD_NUMBER = 3;
+    private java.lang.Object nextBroker_;
+    public boolean hasNextBroker() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    public String getNextBroker() {
+      java.lang.Object ref = nextBroker_;
+      if (ref instanceof String) {
+        return (String) ref;
+      } else {
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString bs = 
+            (org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString) ref;
+        String s = bs.toStringUtf8();
+        if (org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.isValidUtf8(bs)) {
+          nextBroker_ = s;
+        }
+        return s;
+      }
+    }
+    private org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString getNextBrokerBytes() {
+      java.lang.Object ref = nextBroker_;
+      if (ref instanceof String) {
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString b = 
+            org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.copyFromUtf8((String) ref);
+        nextBroker_ = b;
+        return b;
+      } else {
+        return (org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString) ref;
+      }
+    }
+    
     private void initFields() {
       producerId_ = 0L;
       requestId_ = 0L;
+      nextBroker_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -18319,6 +18356,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeUInt64(2, requestId_);
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(3, getNextBrokerBytes());
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -18334,6 +18374,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeUInt64Size(2, requestId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeBytesSize(3, getNextBrokerBytes());
       }
       memoizedSerializedSize = size;
       return size;
@@ -18452,6 +18496,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000001);
         requestId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
+        nextBroker_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
       
@@ -18493,6 +18539,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000002;
         }
         result.requestId_ = requestId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.nextBroker_ = nextBroker_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -18504,6 +18554,9 @@ public final class PulsarApi {
         }
         if (other.hasRequestId()) {
           setRequestId(other.getRequestId());
+        }
+        if (other.hasNextBroker()) {
+          setNextBroker(other.getNextBroker());
         }
         return this;
       }
@@ -18552,6 +18605,11 @@ public final class PulsarApi {
               requestId_ = input.readUInt64();
               break;
             }
+            case 26: {
+              bitField0_ |= 0x00000004;
+              nextBroker_ = input.readBytes();
+              break;
+            }
           }
         }
       }
@@ -18598,6 +18656,42 @@ public final class PulsarApi {
         requestId_ = 0L;
         
         return this;
+      }
+      
+      // optional string next_broker = 3;
+      private java.lang.Object nextBroker_ = "";
+      public boolean hasNextBroker() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      public String getNextBroker() {
+        java.lang.Object ref = nextBroker_;
+        if (!(ref instanceof String)) {
+          String s = ((org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString) ref).toStringUtf8();
+          nextBroker_ = s;
+          return s;
+        } else {
+          return (String) ref;
+        }
+      }
+      public Builder setNextBroker(String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        nextBroker_ = value;
+        
+        return this;
+      }
+      public Builder clearNextBroker() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        nextBroker_ = getDefaultInstance().getNextBroker();
+        
+        return this;
+      }
+      void setNextBroker(org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString value) {
+        bitField0_ |= 0x00000004;
+        nextBroker_ = value;
+        
       }
       
       // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandCloseProducer)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -18715,6 +18715,10 @@ public final class PulsarApi {
     // required uint64 request_id = 2;
     boolean hasRequestId();
     long getRequestId();
+    
+    // optional string next_broker = 3;
+    boolean hasNextBroker();
+    String getNextBroker();
   }
   public static final class CommandCloseConsumer extends
       org.apache.pulsar.shaded.com.google.protobuf.v241.GeneratedMessageLite
@@ -18771,9 +18775,42 @@ public final class PulsarApi {
       return requestId_;
     }
     
+    // optional string next_broker = 3;
+    public static final int NEXT_BROKER_FIELD_NUMBER = 3;
+    private java.lang.Object nextBroker_;
+    public boolean hasNextBroker() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    public String getNextBroker() {
+      java.lang.Object ref = nextBroker_;
+      if (ref instanceof String) {
+        return (String) ref;
+      } else {
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString bs = 
+            (org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString) ref;
+        String s = bs.toStringUtf8();
+        if (org.apache.pulsar.shaded.com.google.protobuf.v241.Internal.isValidUtf8(bs)) {
+          nextBroker_ = s;
+        }
+        return s;
+      }
+    }
+    private org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString getNextBrokerBytes() {
+      java.lang.Object ref = nextBroker_;
+      if (ref instanceof String) {
+        org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString b = 
+            org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.copyFromUtf8((String) ref);
+        nextBroker_ = b;
+        return b;
+      } else {
+        return (org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString) ref;
+      }
+    }
+    
     private void initFields() {
       consumerId_ = 0L;
       requestId_ = 0L;
+      nextBroker_ = "";
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -18806,6 +18843,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeUInt64(2, requestId_);
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBytes(3, getNextBrokerBytes());
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -18821,6 +18861,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
           .computeUInt64Size(2, requestId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += org.apache.pulsar.shaded.com.google.protobuf.v241.CodedOutputStream
+          .computeBytesSize(3, getNextBrokerBytes());
       }
       memoizedSerializedSize = size;
       return size;
@@ -18939,6 +18983,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000001);
         requestId_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000002);
+        nextBroker_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
       
@@ -18980,6 +19026,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000002;
         }
         result.requestId_ = requestId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.nextBroker_ = nextBroker_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -18991,6 +19041,9 @@ public final class PulsarApi {
         }
         if (other.hasRequestId()) {
           setRequestId(other.getRequestId());
+        }
+        if (other.hasNextBroker()) {
+          setNextBroker(other.getNextBroker());
         }
         return this;
       }
@@ -19039,6 +19092,11 @@ public final class PulsarApi {
               requestId_ = input.readUInt64();
               break;
             }
+            case 26: {
+              bitField0_ |= 0x00000004;
+              nextBroker_ = input.readBytes();
+              break;
+            }
           }
         }
       }
@@ -19085,6 +19143,42 @@ public final class PulsarApi {
         requestId_ = 0L;
         
         return this;
+      }
+      
+      // optional string next_broker = 3;
+      private java.lang.Object nextBroker_ = "";
+      public boolean hasNextBroker() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      public String getNextBroker() {
+        java.lang.Object ref = nextBroker_;
+        if (!(ref instanceof String)) {
+          String s = ((org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString) ref).toStringUtf8();
+          nextBroker_ = s;
+          return s;
+        } else {
+          return (String) ref;
+        }
+      }
+      public Builder setNextBroker(String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        nextBroker_ = value;
+        
+        return this;
+      }
+      public Builder clearNextBroker() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        nextBroker_ = getDefaultInstance().getNextBroker();
+        
+        return this;
+      }
+      void setNextBroker(org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString value) {
+        bitField0_ |= 0x00000004;
+        nextBroker_ = value;
+        
       }
       
       // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandCloseConsumer)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/serf/SerfClient.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/serf/SerfClient.java
@@ -65,10 +65,12 @@ public class SerfClient {
     private SerfEndpoint ep;
     private Client client;
     private final String nodeName;
+    private final String rpcIpAddr;
     //private Query query;
 
     public SerfClient(String ip, long port, String nodeName)  {
         this.nodeName = nodeName;
+        this.rpcIpAddr = ip;
         try {
             log.info("SERF CLIENT INIT : {} {} {} ", ip, port,  nodeName);
             ep = new SocketEndpoint(ip, (int) port);
@@ -78,6 +80,14 @@ public class SerfClient {
         catch (Exception e) {
             log.warn("Cannot connect to serf!: {}", e);
         }
+    }
+
+    public String getNodeName() {
+        return this.nodeName;
+    }
+
+    public String getRpcIpAddr() {
+        return this.rpcIpAddr;
     }
 
     //private parseCoordinateResponse() { 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/CoordinateUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/CoordinateUtil.java
@@ -56,10 +56,17 @@ public class CoordinateUtil {
             sumsq += diff*diff;
         }
         
+        System.out.println("Vector diff = "+sumsq);
+        if (Math.sqrt(sumsq) < 1E-6)
+            return 0;
+
         double rtt = Math.sqrt(sumsq) + coordinateA.getHeight() + coordinateB.getHeight();
+
+        System.out.println("RTT after height addition = "+ rtt);
 
         double adjusted = rtt + coordinateA.getAdjustment() + coordinateB.getAdjustment();
 
+        System.out.println("adjustment = "+ adjusted);
         if(adjusted > 0.0) {
             rtt = adjusted;
         }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -424,6 +424,7 @@ message CommandReachedEndOfTopic {
 message CommandCloseProducer {
 	required uint64 producer_id = 1;
 	required uint64 request_id = 2;
+    optional string next_broker = 3;
 }
 
 message CommandCloseConsumer {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -430,6 +430,7 @@ message CommandCloseProducer {
 message CommandCloseConsumer {
 	required uint64 consumer_id = 1;
 	required uint64 request_id = 2;
+    optional string next_broker = 3;
 }
 
 message CommandRedeliverUnacknowledgedMessages {


### PR DESCRIPTION
### Motivation

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

 - Trying to make the client-perceived downtime smaller by removing unnecessary communication with Leader LoadManager and ZK.
 - Enable clients to send to lookup requests directly to the broker that is supposed to host the bundle. 
 - Make the unload+load process faster as perceived by client

### Modifications

Describe the modifications you've done.

 - Disable fetching topic schema from ZK. We are not working with schema-formatted topics anyway, hence lookup of schema is useless rn. 
 - CloseProducer and CloseConsumer commands are annotated with nextBroker hint, which is used by clients to determine which broker should be contacted next to lookup the topic. IMPORTANT : clients now communicate with authoritative = True, hence the broker receiving lookup request will end up owning the bundle.
 - Unloading broker sends an HTTP call to the "nextBroker" after unloading. The HTTP call requests the nextBroker to proactively start to own the topic by writing to ZK. This is better, because the ZK write happens before the clients reconnects to the nextBroker, hence the client does not see the latency of writing to ZK.
 - Small modifications to the client. Added a thread that monitors the /etc/nodeName and /etc/outboundIp files, and checks if they changed. If they changed, the client will reinitialize the Serf client. This is done so that the client can easily switch between Network Coordinate Proxies (gateways).
### Result

After your change, what will change.
